### PR TITLE
Default Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ Ti.App.iOS.registerUserNotificationSettings({
 
 Taken over from [ti.goosh](https://github.com/caffeinalab/ti.goosh):
 
-The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notification_icon.png`.
+If you add this attribute within the `<application/>` section of your `tiapp.xml`:
+
+```xml
+<meta-data android:name="com.google.firebase.messaging.default_notification_icon"
+           android:resource="@drawable/notification_icon"/>
+```
+
+Then FCM will set the notification tray icon taking it from `/platform/android/res/drawable-*/notification_icon.png`.
 
 It should be flat (no gradients), white and face-on perspective.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ti.App.iOS.registerUserNotificationSettings({
 
 Taken over from [ti.goosh](https://github.com/caffeinalab/ti.goosh):
 
-The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notification-icon.png`.
+The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notification_icon.png`.
 
 It should be flat (no gradients), white and face-on perspective.
 
@@ -63,23 +63,23 @@ It should be flat (no gradients), white and face-on perspective.
 88 × 88 area in 96 × 96 (xxxhdpi)
 ```
 
-You can use this script to generate it **once you put** the icon in `drawable-xxxhdpi/notification-icon.png`.
+You can use this script to generate it **once you put** the icon in `drawable-xxxhdpi/notification_icon.png`.
 
 ```sh
 #!/bin/sh
 
-ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notification-icon.png"
+ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notification_icon.png"
 if [ -f "$ICON_SOURCE" ]; then
 	mkdir -p "app/platform/android/res/drawable-xxhdpi"
 	mkdir -p "app/platform/android/res/drawable-xhdpi"
 	mkdir -p "app/platform/android/res/drawable-hdpi"
 	mkdir -p "app/platform/android/res/drawable-mdpi"
-	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notification-icon.png"
-	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notification-icon.png"
-	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notification-icon.png"
-	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notification-icon.png"
+	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notification_icon.png"
+	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notification_icon.png"
+	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notification_icon.png"
+	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notification_icon.png"
 else
-	echo "No 'notification-icon.png' file found in app/platform/android/res/drawable-xxxhdpi"
+	echo "No 'notification_icon.png' file found in app/platform/android/res/drawable-xxxhdpi"
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ If you add this attribute within the `<application/>` section of your `tiapp.xml
            android:resource="@drawable/notification_icon"/>
 ```
 
-Then FCM will set the notification tray icon taking it from `/platform/android/res/drawable-*/notification_icon.png`.
+Then FCM will set the notification tray icon taking it from `[app*]/platform/android/res/drawable-*/notification_icon.png`.
+
+**\*** = Alloy
 
 It should be flat (no gradients), white and face-on perspective.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,43 @@ Ti.App.iOS.registerUserNotificationSettings({
 });
 ```
 
+## Setting the Notification Icon
+Same as the way [ti.goosh](https://github.com/caffeinalab/ti.goosh) does it. From their docs:
+
+The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notificationicon.png`.
+
+It should be flat (no gradients), white and face-on perspective.
+
+**NB: You have to generate the icon with all resolutions.**
+
+```
+22 × 22 area in 24 × 24 (mdpi)
+33 × 33 area in 36 × 36 (hdpi)
+44 × 44 area in 48 × 48 (xhdpi)
+66 × 66 area in 72 × 72 (xxhdpi)
+88 × 88 area in 96 × 96 (xxxhdpi)
+```
+
+You can use this script to generate it **once you put** the icon in `drawable-xxxhdpi/notificationicon.png`.
+
+```sh
+#!/bin/sh
+
+ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notificationicon.png"
+if [ -f "$ICON_SOURCE" ]; then
+	mkdir -p "app/platform/android/res/drawable-xxhdpi"
+	mkdir -p "app/platform/android/res/drawable-xhdpi"
+	mkdir -p "app/platform/android/res/drawable-hdpi"
+	mkdir -p "app/platform/android/res/drawable-mdpi"
+	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notificationicon.png"
+	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notificationicon.png"
+	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notificationicon.png"
+	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notificationicon.png"
+else
+	echo "No notificationicon.png found"
+fi
+```
+
 ## API's
 
 ### `FirebaseCloudMessaging`

--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ Ti.App.iOS.registerUserNotificationSettings({
 });
 ```
 
-## Setting the Notification Icon
-Same as the way [ti.goosh](https://github.com/caffeinalab/ti.goosh) does it. From their docs:
+## Android: Setting the Notification Icon
 
-The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notificationicon.png`.
+Taken over from [ti.goosh](https://github.com/caffeinalab/ti.goosh):
+
+The module sets the notification tray icon taking it from `/platform/android/res/drawable-*/notification-icon.png`.
 
 It should be flat (no gradients), white and face-on perspective.
 
-**NB: You have to generate the icon with all resolutions.**
+> **Note**: You should generate the icon for all resolutions.
 
 ```
 22 × 22 area in 24 × 24 (mdpi)
@@ -62,23 +63,23 @@ It should be flat (no gradients), white and face-on perspective.
 88 × 88 area in 96 × 96 (xxxhdpi)
 ```
 
-You can use this script to generate it **once you put** the icon in `drawable-xxxhdpi/notificationicon.png`.
+You can use this script to generate it **once you put** the icon in `drawable-xxxhdpi/notification-icon.png`.
 
 ```sh
 #!/bin/sh
 
-ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notificationicon.png"
+ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notification-icon.png"
 if [ -f "$ICON_SOURCE" ]; then
 	mkdir -p "app/platform/android/res/drawable-xxhdpi"
 	mkdir -p "app/platform/android/res/drawable-xhdpi"
 	mkdir -p "app/platform/android/res/drawable-hdpi"
 	mkdir -p "app/platform/android/res/drawable-mdpi"
-	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notificationicon.png"
-	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notificationicon.png"
-	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notificationicon.png"
-	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notificationicon.png"
+	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notification-icon.png"
+	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notification-icon.png"
+	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notification-icon.png"
+	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notification-icon.png"
 else
-	echo "No notificationicon.png found"
+	echo "No 'notification-icon.png' file found in app/platform/android/res/drawable-xxxhdpi"
 fi
 ```
 

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -24,8 +24,8 @@
 						<category android:name="${tiapp.properties['id']}"/>
 					</intent-filter>
 				</receiver>
-                <meta-data android:name="com.google.firebase.messaging.default_notification_icon"
-                           android:resource="@drawable/notificationicon"/>
+                		<meta-data android:name="com.google.firebase.messaging.default_notification_icon"
+                           		   android:resource="@drawable/notification_icon"/>
 			</application>
 		</manifest>
 	</android>

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -24,8 +24,6 @@
 						<category android:name="${tiapp.properties['id']}"/>
 					</intent-filter>
 				</receiver>
-                		<meta-data android:name="com.google.firebase.messaging.default_notification_icon"
-                           		   android:resource="@drawable/notification_icon"/>
 			</application>
 		</manifest>
 	</android>

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -24,6 +24,8 @@
 						<category android:name="${tiapp.properties['id']}"/>
 					</intent-filter>
 				</receiver>
+                <meta-data android:name="com.google.firebase.messaging.default_notification_icon"
+                           android:resource="@drawable/notificationicon"/>
 			</application>
 		</manifest>
 	</android>


### PR DESCRIPTION
User can place the default icon at the proper platform/android/res/drawable-* folders and it will be chosen for all fcm notifications as per https://firebase.google.com/docs/cloud-messaging/android/client