### PR TITLE
Android: Default icon, try/catch for tokenrefresh, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Merge the following keys to the `<android>` section of the tiapp.xml in order to
 				  <action android:name="com.google.android.gms.measurement.UPLOAD" />
 			   </intent-filter>
 			</receiver>  
-	
+
 			<service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
 			   <intent-filter>
 				  <action android:name="com.google.android.c2dm.intent.RECEIVE" />
@@ -96,8 +96,14 @@ Merge the following keys to the `<android>` section of the tiapp.xml in order to
 
 ### Setting the Notification Icon
 
-Taken over from [ti.goosh](https://github.com/caffeinalab/ti.goosh):
+You have to place a notification icon "notificationicon.png" into the following folder:
+ '[application_name]/app/platform/android/res/drawable/'
 
+Otherwise the default icon will be used.
+
+#### Alternative
+
+Taken over from [ti.goosh](https://github.com/caffeinalab/ti.goosh):
 If you add this attribute within the `<application/>` section of your `tiapp.xml`:
 
 ```xml
@@ -206,6 +212,7 @@ Read more in the [official Android docs](https://developer.android.com/reference
 ##### `apnsToken` (String, set) - iOS only
 
 ##### `lastData` (Object) - Android only
+The propery `lastData` will contain the data part when you send a notification push message (so both nodes are visible inside the push payload).
 
 #### Events
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.3.0
+version: 1.3.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -55,9 +55,10 @@ public class CloudMessagingModule extends KrollModule
 		// put module init code that needs to run when the application is created
 	}
 
-	@Kroll.method
-	@Kroll.getProperty
-	private KrollDict getLastData()
+	@Kroll
+		.method
+		@Kroll.getProperty
+		private KrollDict getLastData()
 	{
 		KrollDict data = new KrollDict();
 
@@ -139,10 +140,14 @@ public class CloudMessagingModule extends KrollModule
 
 	public void onTokenRefresh(String token)
 	{
-		if (hasListeners("didRefreshRegistrationToken")) {
-			KrollDict data = new KrollDict();
-			data.put("fcmToken", token);
-			fireEvent("didRefreshRegistrationToken", data);
+		try {
+			if (hasListeners("didRefreshRegistrationToken")) {
+				KrollDict data = new KrollDict();
+				data.put("fcmToken", token);
+				fireEvent("didRefreshRegistrationToken", data);
+			}
+		} catch (Exception e) {
+			Log.e(LCAT, "Can't refresh token: " + e.getMessage());
 		}
 	}
 

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -55,10 +55,11 @@ public class CloudMessagingModule extends KrollModule
 		// put module init code that needs to run when the application is created
 	}
 
-	@Kroll
-		.method
-		@Kroll.getProperty
-		private KrollDict getLastData()
+	// clang-format off
+	@Kroll.method
+	@Kroll.getProperty
+	private KrollDict getLastData()
+	// clang-format on
 	{
 		KrollDict data = new KrollDict();
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -149,6 +149,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			int smallIcon = this.getResource("drawable", "notificationicon");
 			if (smallIcon > 0) {
 				builder.setSmallIcon(smallIcon);
+			} else {
+				builder.setSmallIcon(android.R.drawable.stat_sys_warning);
 			}
 		} catch (Exception ex) {
 			Log.e(TAG, "Smallicon exception: " + ex.getMessage());


### PR DESCRIPTION
Bugfix and Readme update:

* set a default icon if none is provided (https://github.com/hansemannn/titanium-firebase-cloud-messaging/issues/28)
* added a try/catch around onTokenRefresh (https://github.com/hansemannn/titanium-firebase-cloud-messaging/issues/29)
* added explanation for `lastData`
* changed the `notificationicon` part in the README

Version 1.3.1

Testversion: https://github.com/hansemannn/titanium-firebase-cloud-messaging/releases/download/untagged-3ab96f30fd16cfa444c7/firebase.cloudmessaging-android-1.3.1.zip

(I've added a draft release)