### PR TITLE
Android: Bugfix for Oreo notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,8 @@ Run it locally with `php filelane.php` or put it on a webserver where you can ex
 				"icon" => "http://via.placeholder.com/150x150",
 				"image" => "http://via.placeholder.com/350x150",	// won't show the big_text
 				"force_show_in_foreground"=> true,
-				"color" => "#ff6600"
+				"color" => "#ff6600",
+				"channelId" => "default"	// or a different channel
 			)
 	);
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.3.1
+version: 1.3.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import org.appcelerator.kroll.KrollFunction;
 import java.util.Map;
 import android.content.Intent;
+import org.json.JSONObject;
 
 @Kroll.module(name = "CloudMessaging", id = "firebase.cloudmessaging")
 public class CloudMessagingModule extends KrollModule
@@ -42,6 +43,7 @@ public class CloudMessagingModule extends KrollModule
 
 	private static final String LCAT = "FirebaseCloudMessaging";
 	private static CloudMessagingModule instance = null;
+	private String notificationData = "";
 
 	public CloudMessagingModule()
 	{
@@ -68,15 +70,17 @@ public class CloudMessagingModule extends KrollModule
 			Bundle extras = intent.getExtras();
 
 			if (extras != null) {
-				if (extras.getString("google.message_id") != null) {
-					for (String key : extras.keySet()) {
-						data.put(key, extras.get(key));
-					}
-
-					data.put("inBackground", true);
+				for (String key : extras.keySet()) {
+					data.put(key, extras.get(key));
 				}
+
+				data.put("inBackground", true);
 			} else {
 				Log.d(LCAT, "Empty extras in Intent");
+				if (notificationData != "") {
+					data = new KrollDict(new JSONObject(notificationData));
+					data.put("inBackground", true);
+				}
 			}
 		} catch (Exception ex) {
 			Log.e(LCAT, "getLastData" + ex);
@@ -225,6 +229,11 @@ public class CloudMessagingModule extends KrollModule
 			return instance;
 		else
 			return new CloudMessagingModule();
+	}
+
+	public void setNotificationData(String data)
+	{
+		notificationData = data;
 	}
 
 	public void parseBootIntent()

--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -26,8 +26,7 @@ public class PushHandlerActivity extends Activity
 			CloudMessagingModule module = CloudMessagingModule.getInstance();
 			Context context = getApplicationContext();
 			String notification = getIntent().getStringExtra("fcm_data");
-			String data = getIntent().getStringExtra("data");
-
+			module.setNotificationData(notification);
 			Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
 			launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
 			launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/android/src/firebase/cloudmessaging/TiFirebaseInstanceIDService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseInstanceIDService.java
@@ -15,6 +15,8 @@ public class TiFirebaseInstanceIDService extends FirebaseInstanceIdService
 		// Get updated InstanceID token.
 		String refreshedToken = FirebaseInstanceId.getInstance().getToken();
 		Log.d(TAG, "Refreshed token: " + refreshedToken);
-		CloudMessagingModule.getInstance().onTokenRefresh(refreshedToken);
+		if (CloudMessagingModule.getInstance() != null) {
+			CloudMessagingModule.getInstance().onTokenRefresh(refreshedToken);
+		}
 	}
 }

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -132,7 +132,11 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		builder.setContentText(params.get("message"));
 		builder.setTicker(params.get("ticker"));
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			builder.setChannelId(params.get("channelId"));
+			if (params.get("channelId") != null && params.get("channelId") != "") {
+				builder.setChannelId(params.get("channelId"));
+			} else {
+				builder.setChannelId("default");
+			}
 		}
 
 		// BigText

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -131,6 +131,9 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		builder.setContentTitle(params.get("title"));
 		builder.setContentText(params.get("message"));
 		builder.setTicker(params.get("ticker"));
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			builder.setChannelId(params.get("channelId"));
+		}
 
 		// BigText
 		if (params.get("big_text") != null && params.get("big_text") != "") {


### PR DESCRIPTION
As mentioned here: https://github.com/hansemannn/titanium-firebase-cloud-messaging/issues/35

* adding the possibility to specify a channelId in the push notification and use it in the builder
* tweaked `lastData` if app is open in background and sending a data only notification
* null check in `onTokenRefresh`