### PR TITLE
Parsing boot intent notification data as a JSON object

### DIFF
--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -243,7 +243,7 @@ public class CloudMessagingModule extends KrollModule
 			String notification = intent.getStringExtra("fcm_data");
 			if (notification != null) {
 				HashMap<String, Object> msg = new HashMap<String, Object>();
-				msg.put("data", notification);
+				msg.put("data", new KrollDict(new JSONObject(notification)));
 				onMessageReceived(msg);
 				intent.removeExtra("fcm_data");
 			} else {


### PR DESCRIPTION
Solves #47 

It seems to work correctly with data messages.

Test PHP code:
```php
<?php $url = 'https://fcm.googleapis.com/fcm/send';

	$fields = array (
		'to' => "<FCM TOKEN>",
		'data' => array(
			"test1" => "value1",
			"test2" => "value2",
			"timestamp"=>date('Y-m-d G:i:s'),
			"title" => "title",
			"message" => "message",
			"big_text"=>"big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text ",
			"big_text_summary"=>"big_text_summary",
			"icon" => "http://via.placeholder.com/150x150",
			"image" => "http://via.placeholder.com/350x150",	// won't show the big_text
			"force_show_in_foreground"=> true,
			"color" => "#ff6600",
			"channelId" => "default"	// or a different channel
		)
	);

	$headers = array (
		'Authorization: key=<SERVER KEY>',
		'Content-Type: application/json'
	);

	$ch = curl_init ();
	curl_setopt ( $ch, CURLOPT_URL, $url );
	curl_setopt ( $ch, CURLOPT_POST, true );
	curl_setopt ( $ch, CURLOPT_HTTPHEADER, $headers );
	curl_setopt ( $ch, CURLOPT_RETURNTRANSFER, true );
	curl_setopt ( $ch, CURLOPT_POSTFIELDS, json_encode($fields));

	$result = curl_exec ( $ch );
	echo $result."\n";
	curl_close ( $ch );
?>
```