### PR TITLE
Fixed force_show_in_foreground parameter when set to false

### DIFF
--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -94,7 +94,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		}
 
 		if (params.get("force_show_in_foreground") != null && params.get("force_show_in_foreground") != "") {
-			showNotification = TiConvert.toBoolean(params.get("force_show_in_foreground"), false);
+			showNotification = showNotification || TiConvert.toBoolean(params.get("force_show_in_foreground"), false);
 		}
 
 		if (params.get("title") == null && params.get("message") == null && params.get("big_text") == null


### PR DESCRIPTION
This PR fixes a bug that prevents data notifications from being shown with the app closed or in background, when sending the `force_show_in_foreground` parameter as false.

Push notification test code:
```php
<?php $url = 'https://fcm.googleapis.com/fcm/send';

	$fields = array (
			'to' => "<FCM TOKEN>",
			'data' => array(
				"test1" => "value1",
				"test2" => "value2",
				"timestamp"=>date('Y-m-d G:i:s'),
				"title" => "title",
				"message" => "message",
				"big_text"=>"big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text ",
				"big_text_summary"=>"big_text_summary",
				"icon" => "http://via.placeholder.com/150x150",
				"image" => "http://via.placeholder.com/350x150",	// won't show the big_text
				"force_show_in_foreground"=> false,
				"color" => "#ff6600",
				"channelId" => "default"	// or a different channel
			)
	);

	$headers = array (
			'Authorization: key=<SERVER KEY>',
			'Content-Type: application/json'
	);

	$ch = curl_init ();
	curl_setopt ( $ch, CURLOPT_URL, $url );
	curl_setopt ( $ch, CURLOPT_POST, true );
	curl_setopt ( $ch, CURLOPT_HTTPHEADER, $headers );
	curl_setopt ( $ch, CURLOPT_RETURNTRANSFER, true );
	curl_setopt ( $ch, CURLOPT_POSTFIELDS, json_encode($fields));

	$result = curl_exec ( $ch );
	echo $result."\n";
	curl_close ( $ch );
?>
```