### PR TITLE
Android: enable default vibration, fix sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use the native Firebase SDK (iOS/Android) in Axway Titanium. This repository is 
 * [Download](#download)
 * [iOS notes](#ios-notes)
 * [Android Notes](#android-notes)
-* [API: Methods, Properties, Events](#api-s)
+* [API: Methods, Properties, Events](#api)
 * [Example](#example)
 * [Build from source](#build)
 
@@ -182,7 +182,7 @@ Supported notification fields:
 * "tag" => "custom_notification_tag",   // push with the same tag will replace each other
 * "sound" => "string" (e.g. "notification.mp3" will play /platform/android/res/raw/notification.mp3)
 
-## API's
+## API
 
 ### `FirebaseCloudMessaging`
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Merge the following keys to the `<android>` section of the tiapp.xml in order to
 </android>   
 ```
 
-Add the google_app_id to `/app/platform/android/res/values/strings.xml`:
+#### Optional:
+In rare cases you need to add the google_app_id to `/app/platform/android/res/values/strings.xml`:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
@@ -161,12 +162,15 @@ Supported data fields:
 * "force_show_in_foreground" => "Boolean" (show notification even app is in foreground)
 * "id" => "int"
 * "color" => will tint the app name and the small icon next to it
+* "vibrate" => "boolean"
+* "sound" => "string" (e.g. "notification.mp3" will play /platform/android/res/raw/notification.mp3)
 
 Supported notification fields:
 * "title" => "string"
 * "body" => "string"
 * "color" => "#00ff00",
 * "tag" => "custom_notification_tag",   // push with the same tag will replace each other
+* "sound" => "string" (e.g. "notification.mp3" will play /platform/android/res/raw/notification.mp3)
 
 ## API's
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Use the native Firebase SDK (iOS/Android) in Axway Titanium. This repository is part of the [Titanium Firebase](https://github.com/hansemannn/titanium-firebase) project.
 
+## Topics
+* [Requirements](#requirements)
+* [Download](#download)
+* [iOS notes](#ios-notes)
+* [Android Notes](#android-notes)
+* [API: Methods, Properties, Events](#api-s)
+* [Example](#example)
+* [Build from source](#build)
+
 ## Requirements
 - [x] The [Firebase Core](https://github.com/hansemannn/titanium-firebase-core) module.
 The options `googleAppID` and `GCMSenderID` are required for Android, or `file` (e.g. `GoogleService-Info.plist`) for iOS.
@@ -53,35 +62,35 @@ Merge the following keys to the `<android>` section of the tiapp.xml in order to
 
 ```xml
 <android xmlns:android="http://schemas.android.com/apk/res/android">
-	<manifest>
-		<application>
-			<service android:name="MY_PACKAGE_NAME.gcm.RegistrationIntentService" android:exported="false" />
+    <manifest>
+    <application>
+    <service android:name="MY_PACKAGE_NAME.gcm.RegistrationIntentService" android:exported="false" />
 
-			<receiver android:name="com.google.android.gms.measurement.AppMeasurementReceiver" android:enabled="true">
-			   <intent-filter>
-				  <action android:name="com.google.android.gms.measurement.UPLOAD" />
-			   </intent-filter>
-			</receiver>  
+    <receiver android:name="com.google.android.gms.measurement.AppMeasurementReceiver" android:enabled="true">
+       <intent-filter>
+      <action android:name="com.google.android.gms.measurement.UPLOAD" />
+       </intent-filter>
+    </receiver>  
 
-			<service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
-			   <intent-filter>
-				  <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-			   </intent-filter>
-			</service>
+    <service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
+       <intent-filter>
+      <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+       </intent-filter>
+    </service>
 
-			<service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
-			   <intent-filter>
-				  <action android:name="com.google.android.c2dm.intent.SEND" />
-			   </intent-filter>
-			</service>
+    <service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
+       <intent-filter>
+      <action android:name="com.google.android.c2dm.intent.SEND" />
+       </intent-filter>
+    </service>
 
-			<service android:name="MY_PACKAGE_NAME.gcm.GcmIDListenerService" android:exported="false">
-			   <intent-filter>
-				  <action android:name="com.google.android.gms.iid.InstanceID" />
-			   </intent-filter>
-			</service>
-		</application>
-	</manifest>
+    <service android:name="MY_PACKAGE_NAME.gcm.GcmIDListenerService" android:exported="false">
+       <intent-filter>
+      <action android:name="com.google.android.gms.iid.InstanceID" />
+       </intent-filter>
+    </service>
+    </application>
+    </manifest>
 </android>   
 ```
 
@@ -91,7 +100,7 @@ In rare cases you need to add the google_app_id to `/app/platform/android/res/va
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-	<string name="google_app_id">1:11111111111:android:aaaaaaaaa</string>
+    <string name="google_app_id">1:11111111111:android:aaaaaaaaa</string>
 </resources>
 ```
 
@@ -136,16 +145,16 @@ Image Magick installed. On macOS, you can install it using `brew install imagema
 
 ICON_SOURCE="app/platform/android/res/drawable-xxxhdpi/notification_icon.png"
 if [ -f "$ICON_SOURCE" ]; then
-	mkdir -p "app/platform/android/res/drawable-xxhdpi"
-	mkdir -p "app/platform/android/res/drawable-xhdpi"
-	mkdir -p "app/platform/android/res/drawable-hdpi"
-	mkdir -p "app/platform/android/res/drawable-mdpi"
-	convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notification_icon.png"
-	convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notification_icon.png"
-	convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notification_icon.png"
-	convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notification_icon.png"
+    mkdir -p "app/platform/android/res/drawable-xxhdpi"
+    mkdir -p "app/platform/android/res/drawable-xhdpi"
+    mkdir -p "app/platform/android/res/drawable-hdpi"
+    mkdir -p "app/platform/android/res/drawable-mdpi"
+    convert "$ICON_SOURCE" -resize 72x72 "app/platform/android/res/drawable-xxhdpi/notification_icon.png"
+    convert "$ICON_SOURCE" -resize 48x48 "app/platform/android/res/drawable-xhdpi/notification_icon.png"
+    convert "$ICON_SOURCE" -resize 36x36 "app/platform/android/res/drawable-hdpi/notification_icon.png"
+    convert "$ICON_SOURCE" -resize 24x24 "app/platform/android/res/drawable-mdpi/notification_icon.png"
 else
-	echo "No 'notification_icon.png' file found in app/platform/android/res/drawable-xxxhdpi"
+    echo "No 'notification_icon.png' file found in app/platform/android/res/drawable-xxxhdpi"
 fi
 ```
 
@@ -200,15 +209,27 @@ so receive the `gcm.message_id` key from the notification payload instead.
 ##### `unsubscribeFromTopic(topic)`
   - `topic` (String)
 
+##### `setNotificationChannel(channel)` - Android-only
+  - `channel` (NotificationChannel Object) Use `Ti.Android.NotificationManager.createNotificationChannel()` to create the channel and pass it to the function. See [Titanium.Android.NotificationChannel](https://docs.appcelerator.com/platform/latest/#!/api/Titanium.Android.NotificationChannel)
+
+  _Prefered way_ to set a channel. As an alternative you can use `createNotificationChannel()`
+
 ##### `createNotificationChannel(parameters)` - Android-only
 
-  - `parameters` (Object)
-    - `sound` (String) optional, refers to a sound file (without extension) at `platform/android/res/raw`. If sound == "default" or not passed in, will use the default sound. If sound == "silent" the channel will have no sound
-    - `channelId` (String) optional, defaults to "default"
-    - `channelName` (String) optional, defaults to `channelId`
-    - `importance` (String) optional, either "low", "high", "default". Defaults to "default", unless sound == "silent", then defaults to "low".
+- `parameters` (Object)
+  - `sound` (String) optional, refers to a sound file (without extension) at `platform/android/res/raw`. If sound == "default" or not passed in, will use the default sound. If sound == "silent" the channel will have no sound
+  - `channelId` (String) optional, defaults to "default"
+  - `channelName` (String) optional, defaults to `channelId`
+  - `importance` (String) optional, either "low", "high", "default". Defaults to "default", unless sound == "silent", then defaults to "low".
+  - `lights` (Boolean) optional, defaults to `false`
+  - `showBadge` (Boolean) optional, defaults to `false`
 
-Read more in the [official Android docs](https://developer.android.com/reference/android/app/NotificationChannel).
+  Read more in the [official Android docs](https://developer.android.com/reference/android/app/NotificationChannel).
+
+##### `setForceShowInForeground(showInForeground)` - Android-only
+  - `showInForeground` (Boolean) Force the notifications to be shown in foreground.
+
+
 
 #### Properties
 
@@ -265,12 +286,24 @@ fcm.addEventListener('didReceiveMessage', function(e) {
 
 // Android-only: For configuring custom sounds and importance for the generated system
 // notifications when app is in the background
-OS_ANDROID && fcm.createNotificationChannel({
-    sound: 'warn_sound',
-    channelId: 'general',
-    channelName: 'General Notifications',
-    importance: 'high' //will pop in from the top and make a sound
-})
+if (OS_ANDROID) {
+    // fcm.createNotificationChannel({
+    //     sound: 'warn_sound',
+    //     channelId: 'general',
+    //     channelName: 'General Notifications',
+    //     importance: 'high'
+    // })
+
+    var channel = Ti.Android.NotificationManager.createNotificationChannel({
+        id: 'my_channel',
+        name: 'TEST CHANNEL',
+        importance: Ti.Android.IMPORTANCE_DEFAULT,
+        enableLights: true,
+        enableVibration: true,
+        showBadge: true
+    });
+    fcm.notificationChannel = channel;
+}
 
 // Register the device with the FCM service.
 fcm.registerForPushNotifications();
@@ -286,8 +319,8 @@ if (fcm.fcmToken) {
 fcm.subscribeToTopic('testTopic');
 
 if (OS_ANDROID){
-	// display last data:
-	Ti.API.info("Last data: " + fcm.lastData);
+    // display last data:
+    Ti.API.info("Last data: " + fcm.lastData);
 }
 ```
 
@@ -334,45 +367,45 @@ Run it locally with `php filelane.php` or put it on a webserver where you can ex
 ```php
 <?php $url = 'https://fcm.googleapis.com/fcm/send';
 
-	$fields = array (
-			'to' => "TOKEN_ID",
-			// 'to' => "/topics/test",
-			/* 'notification' => array (
-			 		"title" => "TiFirebaseMessaging",
-			 		"body" => "Message received 📱😂",
-			 		"timestamp"=>date('Y-m-d G:i:s'),
-			),*/
-			'data' => array(
-				"test1" => "value1",
-				"test2" => "value2",
-				"timestamp"=>date('Y-m-d G:i:s'),
-				"title" => "title",
-				"message" => "message",
-				"big_text"=>"big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text ",
-				"big_text_summary"=>"big_text_summary",
-				"icon" => "http://via.placeholder.com/150x150",
-				"image" => "http://via.placeholder.com/350x150",	// won't show the big_text
-				"force_show_in_foreground"=> true,
-				"color" => "#ff6600",
-				"channelId" => "default"	// or a different channel
-			)
-	);
+    $fields = array (
+    'to' => "TOKEN_ID",
+    // 'to' => "/topics/test",
+    /* 'notification' => array (
+     		"title" => "TiFirebaseMessaging",
+     		"body" => "Message received 📱😂",
+     		"timestamp"=>date('Y-m-d G:i:s'),
+    ),*/
+    'data' => array(
+    "test1" => "value1",
+    "test2" => "value2",
+    "timestamp"=>date('Y-m-d G:i:s'),
+    "title" => "title",
+    "message" => "message",
+    "big_text"=>"big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text big text even more text ",
+    "big_text_summary"=>"big_text_summary",
+    "icon" => "http://via.placeholder.com/150x150",
+    "image" => "http://via.placeholder.com/350x150",	// won't show the big_text
+    "force_show_in_foreground"=> true,
+    "color" => "#ff6600",
+    "channelId" => "default"	// or a different channel
+    )
+    );
 
-	$headers = array (
-			'Authorization: key=API_KEY',
-			'Content-Type: application/json'
-	);
+    $headers = array (
+    'Authorization: key=API_KEY',
+    'Content-Type: application/json'
+    );
 
-	$ch = curl_init ();
-	curl_setopt ( $ch, CURLOPT_URL, $url );
-	curl_setopt ( $ch, CURLOPT_POST, true );
-	curl_setopt ( $ch, CURLOPT_HTTPHEADER, $headers );
-	curl_setopt ( $ch, CURLOPT_RETURNTRANSFER, true );
-	curl_setopt ( $ch, CURLOPT_POSTFIELDS, json_encode($fields));
+    $ch = curl_init ();
+    curl_setopt ( $ch, CURLOPT_URL, $url );
+    curl_setopt ( $ch, CURLOPT_POST, true );
+    curl_setopt ( $ch, CURLOPT_HTTPHEADER, $headers );
+    curl_setopt ( $ch, CURLOPT_RETURNTRANSFER, true );
+    curl_setopt ( $ch, CURLOPT_POSTFIELDS, json_encode($fields));
 
-	$result = curl_exec ( $ch );
-	echo $result."\n";
-	curl_close ( $ch );
+    $result = curl_exec ( $ch );
+    echo $result."\n";
+    curl_close ( $ch );
 ?>
 
 ```

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Supported data fields:
 Supported notification fields:
 * "title" => "string"
 * "body" => "string"
+* "color" => "#00ff00",
+* "tag" => "custom_notification_tag",   // push with the same tag will replace each other
 
 ## API's
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.4.0
+version: 1.4.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/manifest
+++ b/android/manifest
@@ -2,13 +2,13 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.4.1
+version: 1.5.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging
 author: Michael Gangolf
 license: Apache 2
-copyright: Copyright (c) 2018 by Michael Gangolf
+copyright: Copyright (c) 2018-present by Michael Gangolf
 
 # these should not be edited
 name: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -199,6 +199,9 @@ public class CloudMessagingModule extends KrollModule
 		}
 
 		NotificationChannel channel = new NotificationChannel(channelId, channelName, importanceVal);
+		channel.enableVibration(true);
+		channel.enableLights(true);
+		channel.setShowBadge(true);
 		if (soundUri != null) {
 			AudioAttributes audioAttributes = new AudioAttributes.Builder()
 												  .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -19,6 +19,8 @@ import android.media.AudioAttributes;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.KrollObject;
 import org.appcelerator.kroll.annotations.Kroll;
@@ -44,6 +46,7 @@ public class CloudMessagingModule extends KrollModule
 
 	private static final String LCAT = "FirebaseCloudMessaging";
 	private static CloudMessagingModule instance = null;
+	private static final String FORCE_SHOW_IN_FOREGROUND = "titanium.firebase.cloudmessaging.key";
 	private String notificationData = "";
 
 	public CloudMessagingModule()
@@ -245,6 +248,28 @@ public class CloudMessagingModule extends KrollModule
 		NotificationManager notificationManager =
 			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.createNotificationChannel(channelProxy.getNotificationChannel());
+	}
+
+	// clang-format off
+	@Kroll.setProperty
+	@Kroll.method
+	public void setForceShowInForeground(final Boolean showInForeground)
+	// clang-format on
+	{
+		Context context = Utils.getApplicationContext();
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		SharedPreferences.Editor editor = prefs.edit();
+		editor.putBoolean(FORCE_SHOW_IN_FOREGROUND, showInForeground);
+		editor.commit();
+	}
+
+	@Kroll.getProperty
+	public Boolean forceShowInForeground()
+	{
+		Context context = Utils.getApplicationContext();
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		return prefs.getBoolean(FORCE_SHOW_IN_FOREGROUND, false);
 	}
 
 	public static CloudMessagingModule getInstance()

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -36,6 +36,7 @@ import org.appcelerator.kroll.KrollFunction;
 import java.util.Map;
 import android.content.Intent;
 import org.json.JSONObject;
+import ti.modules.titanium.android.notificationmanager.NotificationChannelProxy;
 
 @Kroll.module(name = "CloudMessaging", id = "firebase.cloudmessaging")
 public class CloudMessagingModule extends KrollModule
@@ -181,6 +182,9 @@ public class CloudMessagingModule extends KrollModule
 		String importance = (String) options.optString("importance", sound.equals("silent") ? "low" : "default");
 		String channelId = (String) options.optString("channelId", "default");
 		String channelName = (String) options.optString("channelName", channelId);
+		Boolean vibration = (Boolean) options.optBoolean("vibrate", false);
+		Boolean lights = (Boolean) options.optBoolean("lights", false);
+		Boolean showBadge = (Boolean) options.optBoolean("showBadge", false);
 		int importanceVal = NotificationManager.IMPORTANCE_DEFAULT;
 		if (importance.equals("low")) {
 			importanceVal = NotificationManager.IMPORTANCE_LOW;
@@ -199,9 +203,9 @@ public class CloudMessagingModule extends KrollModule
 		}
 
 		NotificationChannel channel = new NotificationChannel(channelId, channelName, importanceVal);
-		channel.enableVibration(true);
-		channel.enableLights(true);
-		channel.setShowBadge(true);
+		channel.enableVibration(vibration);
+		channel.enableLights(lights);
+		channel.setShowBadge(showBadge);
 		if (soundUri != null) {
 			AudioAttributes audioAttributes = new AudioAttributes.Builder()
 												  .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
@@ -224,6 +228,23 @@ public class CloudMessagingModule extends KrollModule
 	public void apnsToken(String str)
 	{
 		// empty
+	}
+
+	// clang-format off
+	@Kroll.setProperty
+	@Kroll.method
+	public void setNotificationChannel(Object channel)
+	// clang-format on
+	{
+		if (!(channel instanceof NotificationChannelProxy)) {
+			return;
+		}
+
+		Context context = Utils.getApplicationContext();
+		NotificationChannelProxy channelProxy = (NotificationChannelProxy) channel;
+		NotificationManager notificationManager =
+			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		notificationManager.createNotificationChannel(channelProxy.getNotificationChannel());
 	}
 
 	public static CloudMessagingModule getInstance()

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -159,7 +159,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		builder.setAutoCancel(true);
 		builder.setPriority(priority);
 		builder.setContentTitle(params.get("title"));
-		if (TiConvert.toString(params.get("alert"), "") != "") {
+		if (params.get("alert") != null) {
 			// OneSignal uses alert for the message
 			builder.setContentText(params.get("alert"));
 		} else {

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -1,12 +1,10 @@
 package firebase.cloudmessaging;
 
-import android.app.NotificationChannel;
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.media.RingtoneManager;
-import android.net.Uri;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -26,6 +24,8 @@ import java.util.Map;
 import org.json.JSONObject;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.TiApplication;
+import android.net.Uri;
+import android.media.RingtoneManager;
 
 public class TiFirebaseMessagingService extends FirebaseMessagingService
 {
@@ -88,6 +88,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		Boolean appInForeground = TiApplication.isCurrentActivityInForeground();
 		Boolean showNotification = true;
 		Context context = getApplicationContext();
+		Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 
 		if (appInForeground) {
 			showNotification = false;
@@ -124,13 +125,14 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		// Start building notification
 
 		NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
-		int builder_defaults = 0;
 		builder.setContentIntent(contentIntent);
 		builder.setAutoCancel(true);
-		builder.setPriority(2);
+		builder.setPriority(Notification.PRIORITY_MAX);
 		builder.setContentTitle(params.get("title"));
 		builder.setContentText(params.get("message"));
 		builder.setTicker(params.get("ticker"));
+		builder.setSound(defaultSoundUri);
+		builder.setDefaults(Notification.DEFAULT_ALL);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			if (params.get("channelId") != null && params.get("channelId") != "") {
 				builder.setChannelId(params.get("channelId"));
@@ -208,7 +210,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		// Send
 		NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-		notificationManager.notify(null, id, builder.build());
+		notificationManager.notify(id, builder.build());
 		return true;
 	}
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -84,6 +84,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 	private Boolean showNotification(RemoteMessage remoteMessage)
 	{
+		CloudMessagingModule module = CloudMessagingModule.getInstance();
 		Map<String, String> params = remoteMessage.getData();
 		JSONObject jsonData = new JSONObject(params);
 		Boolean appInForeground = TiApplication.isCurrentActivityInForeground();
@@ -99,6 +100,10 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		if (params.get("force_show_in_foreground") != null && params.get("force_show_in_foreground") != "") {
 			showNotification = showNotification || TiConvert.toBoolean(params.get("force_show_in_foreground"), false);
+		}
+
+		if (module.forceShowInForeground()) {
+			showNotification = module.forceShowInForeground();
 		}
 
 		if (TiConvert.toBoolean(params.get("vibrate"), false)) {

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -4,6 +4,7 @@
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 		<manifest package="firebase.cloudmessaging">
 			<uses-permission android:name="android.permission.WAKE_LOCK"/>
+			<uses-permission android:name="android.permission.VIBRATE"/>
 			<application>
 				<service android:name="firebase.cloudmessaging.TiFirebaseMessagingService" android:exported="false">
 					<intent-filter>

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -35,6 +35,6 @@
 		<module>firebase.core</module>
 
 		<!-- Require Ti.PlayServices (https://github.com/appcelerator-modules/ti.playservices) -->
-		<module platform="android">ti.playservices</module>
+		<module platform="android" version="11.0.40">ti.playservices</module>
 	</modules>
 </ti:module>


### PR DESCRIPTION
https://github.com/hansemannn/titanium-firebase-cloud-messaging/issues/56

* [x] enable vibration (parameter in data field)
* [x] add permission
* [x] test vibration data message
* [x] test everything with sound
* [x] test vibration with notification message
* [x] custom sound update
* [x] use `alert` field if available (e.g. OneSignal)

Release notes:
* enable vibration with `vibrate` in the data part
* custom sounds work
* priority can be set with `priority` in the data part
* if there is an `alert` field (e.g. OneSignal) it will be used as a message
* set default playservices to `11.0.40`
* added `setNotificationChannel()` so you can create the channel with `Ti.Android.NotificationManager.createNotificationChannel()`
* added `setForceShowInForeground()` to set the forceShowInForeground inside the app instead of the push.

Testversion: [firebase.cloudmessaging-android-1.5.0.zip](http://migaweb.de/firebase.cloudmessaging-android-1.5.0.zip)