### PR TITLE
Forcing Android notifications to be shown in the foreground locally

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.4.0
+version: 1.4.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -36,6 +36,8 @@ import org.appcelerator.kroll.KrollFunction;
 import java.util.Map;
 import android.content.Intent;
 import org.json.JSONObject;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 
 @Kroll.module(name = "CloudMessaging", id = "firebase.cloudmessaging")
 public class CloudMessagingModule extends KrollModule
@@ -252,5 +254,26 @@ public class CloudMessagingModule extends KrollModule
 		} catch (Exception ex) {
 			Log.e(LCAT, "parseBootIntent" + ex);
 		}
+	}
+
+	private static final String FORCE_SHOW_NOTIFICATION_WHILE_FOREGROUND_KEY = "titanium.firebase.cloudmessaging.key" ;
+
+	@Kroll.setProperty
+	public void setForceShowNotificationWhileInForeground(final Boolean forceShowNotificationWhileInForeground)
+	{
+		Context context = Utils.getApplicationContext();
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+		SharedPreferences.Editor editor = prefs.edit();
+		editor.putBoolean(FORCE_SHOW_NOTIFICATION_WHILE_FOREGROUND_KEY, forceShowNotificationWhileInForeground);
+		editor.commit();
+	}
+
+	@Kroll.getProperty
+	public Boolean getForceShowNotificationWhileInForeground()
+	{
+		Context context = Utils.getApplicationContext();
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		return prefs.getBoolean(FORCE_SHOW_NOTIFICATION_WHILE_FOREGROUND_KEY, false);
 	}
 }

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -88,6 +88,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		Boolean appInForeground = TiApplication.isCurrentActivityInForeground();
 		Boolean showNotification = true;
 		Context context = getApplicationContext();
+		CloudMessagingModule module = CloudMessagingModule.getInstance();
 
 		if (appInForeground) {
 			showNotification = false;
@@ -95,12 +96,16 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		if (params.get("force_show_in_foreground") != null && params.get("force_show_in_foreground") != "") {
 			showNotification = showNotification || TiConvert.toBoolean(params.get("force_show_in_foreground"), false);
-		}
+		} 
 
 		if (params.get("title") == null && params.get("message") == null && params.get("big_text") == null
 			&& params.get("big_text_summary") == null && params.get("ticker") == null && params.get("image") == null) {
 			// no actual content - don't show it
 			showNotification = false;
+		}
+
+		if (module.getForceShowNotificationWhileInForeground()) {
+			showNotification = module.getForceShowNotificationWhileInForeground();
 		}
 
 		if (!showNotification) {


### PR DESCRIPTION
Right now, notifications are shown:

- when the app is in the background
- when we set in the server-side `"force_show_in_foreground": "true"`, with something like

```json
{
    "payload": {
        "android": {
            "data": {
                "force_show_in_foreground": "true",
                "title": "a title",
                "message": "One message"
            },
            "priority": "HIGH",
            "ttl": 5000
        }
    }
}
```

But 

- what if we want to enable locally the notifications to be shown locally, without changing our server-side code?

Now we can do:

```js
var fcm = require('firebase.cloudmessaging');

//...
fcm.forceShowNotificationWhileInForeground = true;
``` 

Not sure if my approach was OK or not, but I think this can be a valuable addition to the module. Using locally in a project and works like a charm.