### PR TITLE
Android: Circular Icon in notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Supported data fields:
 * "big_text_summary" => "string"
 * "icon" => "Remote URL"
 * "image" => "Remote URL"
+* "rounded_large_icon" => "Boolean" (to display the largeIcon as a rounded image when the icon field is present)
 * "force_show_in_foreground" => "Boolean" (show notification even app is in foreground)
 * "id" => "int"
 * "color" => will tint the app name and the small icon next to it

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.2
+version: 2.0.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -103,7 +103,7 @@ public class CloudMessagingModule extends KrollModule
 					fcmToken = instanceIdResult.getToken();
 					onTokenRefresh(fcmToken);
 				}
-		});
+			});
 		parseBootIntent();
 	}
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -34,7 +34,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 	private static final AtomicInteger atomic = new AtomicInteger(0);
 
 	@Override
-	public void onNewToken(String s) {
+	public void onNewToken(String s)
+	{
 		super.onNewToken(s);
 		CloudMessagingModule module = CloudMessagingModule.getInstance();
 		if (module != null) {
@@ -234,15 +235,11 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		if (params.get("icon") != null && params.get("icon") != "") {
 			try {
 				Bitmap icon = this.getBitmapFromURL(params.get("icon"));
-
-				if(params.get("icon_as_circle") != null && params.get("icon_as_circle") != "") {
-					try {
-						//Converting the icon Bitmap to a circle shaped Bitmap
-						boolean circle = Boolean.parseBoolean(params.get("icon_as_circle"));
-						if (circle) icon = Utils.getCircleBitmap(icon);
-					} catch (Exception ex) {
-						Log.e(TAG, "Icon as circle exception: " + ex.getMessage());
-					}
+				//Check if the icon should be displayed as a circle
+				if (params.get("rounded_large_icon") != null
+					&& Boolean.parseBoolean(params.get("rounded_large_icon"))) {
+					//Converting the icon Bitmap to a circle shaped Bitmap
+					icon = Utils.getCircleBitmap(icon);
 				}
 
 				builder.setLargeIcon(icon);

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -236,8 +236,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			try {
 				Bitmap icon = this.getBitmapFromURL(params.get("icon"));
 				//Check if the icon should be displayed as a circle
-				if (params.get("rounded_large_icon") != null
-					&& Boolean.parseBoolean(params.get("rounded_large_icon"))) {
+				if (jsonData.optBoolean("rounded_large_icon")) {
 					//Converting the icon Bitmap to a circle shaped Bitmap
 					icon = Utils.getCircleBitmap(icon);
 				}

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -234,6 +234,17 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		if (params.get("icon") != null && params.get("icon") != "") {
 			try {
 				Bitmap icon = this.getBitmapFromURL(params.get("icon"));
+
+				if(params.get("icon_as_circle") != null && params.get("icon_as_circle") != "") {
+					try {
+						//Converting the icon Bitmap to a circle shaped Bitmap
+						boolean circle = Boolean.parseBoolean(params.get("icon_as_circle"));
+						if (circle) icon = Utils.getCircleBitmap(icon);
+					} catch (Exception ex) {
+						Log.e(TAG, "Icon as circle exception: " + ex.getMessage());
+					}
+				}
+
 				builder.setLargeIcon(icon);
 			} catch (Exception ex) {
 				Log.e(TAG, "Icon exception: " + ex.getMessage());

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -241,7 +241,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 					//Converting the icon Bitmap to a circle shaped Bitmap
 					icon = Utils.getCircleBitmap(icon);
 				}
-
 				builder.setLargeIcon(icon);
 			} catch (Exception ex) {
 				Log.e(TAG, "Icon exception: " + ex.getMessage());

--- a/android/src/firebase/cloudmessaging/Utils.java
+++ b/android/src/firebase/cloudmessaging/Utils.java
@@ -1,6 +1,14 @@
 package firebase.cloudmessaging;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import org.appcelerator.titanium.TiApplication;
 
 public final class Utils

--- a/android/src/firebase/cloudmessaging/Utils.java
+++ b/android/src/firebase/cloudmessaging/Utils.java
@@ -31,4 +31,47 @@ public final class Utils
 	{
 		return TiApplication.getInstance().getApplicationContext();
 	}
+
+	/**
+     * Returns a circle shaped Bitmap of a square or rectangular input Bitmap
+     * @param bitmap
+     * @return
+     */
+	public static Bitmap getCircleBitmap(Bitmap bitmap) {
+        Bitmap output;
+        Rect srcRect, dstRect;
+        float r;
+        final int width = bitmap.getWidth();
+        final int height = bitmap.getHeight();
+
+        if (width > height){
+            output = Bitmap.createBitmap(height, height, Bitmap.Config.ARGB_8888);
+            int left = (width - height) / 2;
+            int right = left + height;
+            srcRect = new Rect(left, 0, right, height);
+            dstRect = new Rect(0, 0, height, height);
+            r = height / 2;
+        }else{
+            output = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
+            int top = (height - width)/2;
+            int bottom = top + width;
+            srcRect = new Rect(0, top, width, bottom);
+            dstRect = new Rect(0, 0, width, width);
+            r = width / 2;
+        }
+
+        Canvas canvas = new Canvas(output);
+
+        final Paint paint = new Paint(Color.TRANSPARENT);
+        paint.setAntiAlias(true);
+
+        canvas.drawARGB(0, 0, 0, 0);
+        canvas.drawCircle(r, r, r, paint);
+        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+        canvas.drawBitmap(bitmap, srcRect, dstRect, paint);
+
+        bitmap.recycle();
+
+		return output;
+    }
 }

--- a/android/src/firebase/cloudmessaging/Utils.java
+++ b/android/src/firebase/cloudmessaging/Utils.java
@@ -45,41 +45,42 @@ public final class Utils
      * @param bitmap
      * @return
      */
-	public static Bitmap getCircleBitmap(Bitmap bitmap) {
-        Bitmap output;
-        Rect srcRect, dstRect;
-        float r;
-        final int width = bitmap.getWidth();
-        final int height = bitmap.getHeight();
+	public static Bitmap getCircleBitmap(Bitmap bitmap)
+	{
+		Bitmap output;
+		Rect srcRect, dstRect;
+		float r;
+		final int width = bitmap.getWidth();
+		final int height = bitmap.getHeight();
 
-        if (width > height){
-            output = Bitmap.createBitmap(height, height, Bitmap.Config.ARGB_8888);
-            int left = (width - height) / 2;
-            int right = left + height;
-            srcRect = new Rect(left, 0, right, height);
-            dstRect = new Rect(0, 0, height, height);
-            r = height / 2;
-        }else{
-            output = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
-            int top = (height - width)/2;
-            int bottom = top + width;
-            srcRect = new Rect(0, top, width, bottom);
-            dstRect = new Rect(0, 0, width, width);
-            r = width / 2;
-        }
+		if (width > height) {
+			output = Bitmap.createBitmap(height, height, Bitmap.Config.ARGB_8888);
+			int left = (width - height) / 2;
+			int right = left + height;
+			srcRect = new Rect(left, 0, right, height);
+			dstRect = new Rect(0, 0, height, height);
+			r = height / 2;
+		} else {
+			output = Bitmap.createBitmap(width, width, Bitmap.Config.ARGB_8888);
+			int top = (height - width) / 2;
+			int bottom = top + width;
+			srcRect = new Rect(0, top, width, bottom);
+			dstRect = new Rect(0, 0, width, width);
+			r = width / 2;
+		}
 
-        Canvas canvas = new Canvas(output);
+		Canvas canvas = new Canvas(output);
 
-        final Paint paint = new Paint(Color.TRANSPARENT);
-        paint.setAntiAlias(true);
+		final Paint paint = new Paint(Color.TRANSPARENT);
+		paint.setAntiAlias(true);
 
-        canvas.drawARGB(0, 0, 0, 0);
-        canvas.drawCircle(r, r, r, paint);
-        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
-        canvas.drawBitmap(bitmap, srcRect, dstRect, paint);
+		canvas.drawARGB(0, 0, 0, 0);
+		canvas.drawCircle(r, r, r, paint);
+		paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+		canvas.drawBitmap(bitmap, srcRect, dstRect, paint);
 
-        bitmap.recycle();
+		bitmap.recycle();
 
 		return output;
-    }
+	}
 }


### PR DESCRIPTION
Added `getCircleBitmap()` method in _Utils.java_ and added a check for the `icon_as_circle` parameter in _TiFirebaseMessagingService.java_

There could be done more to smoothen the border of the circular Bitmap as it might appear a bit pixelated for some images: [smooth canvas shapes with anti-aliasing](https://medium.com/@ali.muzaffar/android-why-your-canvas-shapes-arent-smooth-aa2a3f450eb5)