### PR TITLE
Moved module requirement below core.configure - fixes #65

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,11 +1,10 @@
 var core = require('firebase.core');
-// var fcm = require('firebase.cloudmessaging'); // moved this below core.configure() to fix iOS bug where firebase core context not yet available.
 var isAndroid = Ti.Platform.osname === 'android';
 
 // Configure core module (required for all Firebase modules)
 core.configure();
 
-// include cloudmessaging module here
+// Important: Include cloud messaging module after the initial configure()
 var fcm = require('firebase.cloudmessaging');
 
 // Called when the Firebase token is ready

--- a/example/app.js
+++ b/example/app.js
@@ -1,9 +1,12 @@
 var core = require('firebase.core');
-var fcm = require('firebase.cloudmessaging');
+// var fcm = require('firebase.cloudmessaging'); // moved this below core.configure() to fix iOS bug where firebase core context not yet available.
 var isAndroid = Ti.Platform.osname === 'android';
 
 // Configure core module (required for all Firebase modules)
 core.configure();
+
+// include cloudmessaging module here
+var fcm = require('firebase.cloudmessaging');
 
 // Called when the Firebase token is ready
 fcm.addEventListener('didRefreshRegistrationToken', onToken);


### PR DESCRIPTION
Topic subscription was broken on IOS. When moving the inclusion (initialisation) of the require of te firebase.cloudmessaging module below the core.configure() statement, it does work correct.