### PR TITLE
Android: Handle empty sounds, error event, Readme update, clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Use the native Firebase SDK (iOS/Android) in Axway Titanium. This repository is 
 The options `googleAppID` and `GCMSenderID` are required for Android, or `file` (e.g. `GoogleService-Info.plist`) for iOS.
 - [x] iOS: Titanium SDK 6.3.0+
 - [x] Android: Titanium SDK 7.0.0+, [Ti.PlayServices](https://github.com/appcelerator-modules/ti.playservices) module
+- [x] Read the [Firebase-Core](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
+
 
 ## Download
 - [x] [Stable release](https://github.com/hansemannn/titanium-firebase-cloud-messaging/releases)
@@ -94,9 +96,9 @@ Merge the following keys to the `<android>` section of the tiapp.xml in order to
 </android>   
 ```
 
-#### Optional
+#### XML
 
-In rare cases you need to add the google_app_id to `/app/platform/android/res/values/strings.xml`:
+You need to add the google_app_id to `/app/platform/android/res/values/strings.xml`:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
@@ -185,33 +187,33 @@ Supported notification fields:
 
 #### Methods
 
-##### `registerForPushNotifications()`
+`registerForPushNotifications()`
 
-##### `appDidReceiveMessage(parameters)` - iOS only
+`appDidReceiveMessage(parameters)` (iOS only)
   - `parameters` (Object)
 
 Note: Only call this method if method swizzling is disabled (enabled by default). Messages are received via the native delegates instead,
 so receive the `gcm.message_id` key from the notification payload instead.
 
-##### `sendMessage(parameters)`
+`sendMessage(parameters)`
   - `parameters` (Object)
     - `messageID` (String)
     - `to` (String)
     - `timeToLive` (Number)
     - `data` (Object)
 
-##### `subscribeToTopic(topic)`
+`subscribeToTopic(topic)`
   - `topic` (String)
 
-##### `unsubscribeFromTopic(topic)`
+`unsubscribeFromTopic(topic)`
   - `topic` (String)
 
-##### `setNotificationChannel(channel)` - Android-only
+`setNotificationChannel(channel)` - Android-only
   - `channel` (NotificationChannel Object) Use `Ti.Android.NotificationManager.createNotificationChannel()` to create the channel and pass it to the function. See [Titanium.Android.NotificationChannel](https://docs.appcelerator.com/platform/latest/#!/api/Titanium.Android.NotificationChannel)
 
   _Prefered way_ to set a channel. As an alternative you can use `createNotificationChannel()`
 
-##### `createNotificationChannel(parameters)` - Android-only
+`createNotificationChannel(parameters)` - Android-only
 
 - `parameters` (Object)
   - `sound` (String) optional, refers to a sound file (without extension) at `platform/android/res/raw`. If sound == "default" or not passed in, will use the default sound. If sound == "silent" the channel will have no sound
@@ -223,41 +225,44 @@ so receive the `gcm.message_id` key from the notification payload instead.
 
   Read more in the [official Android docs](https://developer.android.com/reference/android/app/NotificationChannel).
 
-##### `setForceShowInForeground(showInForeground)` - Android-only
+`setForceShowInForeground(showInForeground)` - Android-only
   - `showInForeground` (Boolean) Force the notifications to be shown in foreground.
 
 
 
 #### Properties
 
-##### `shouldEstablishDirectChannel` (Number, get/set)
+`shouldEstablishDirectChannel` (Number, get/set)
 
-##### `fcmToken` (String, get)
+`fcmToken` (String, get)
 
-##### `apnsToken` (String, set) - iOS only
+`apnsToken` (String, set) (iOS only)
 
-##### `lastData` (Object) - Android only
+`lastData` (Object) (Android only)
 The propery `lastData` will contain the data part when you send a notification push message (so both nodes are visible inside the push payload).
 
 #### Events
 
-##### `didReceiveMessage`
+`didReceiveMessage`
   - `message` (Object)
 
-iOS Note: This method is only called on iOS 10+ and only for direct messages sent by Firebase. Normal Firebase push notifications
-are still delivered via the Titanium notification events, e.g.
-```js
-Ti.App.iOS.addEventListener('notification', function(event) {
-  // Handle foreground notification
-});
+	iOS Note: This method is only called on iOS 10+ and only for direct messages sent by Firebase. Normal Firebase push notifications
+	are still delivered via the Titanium notification events, e.g.
+	```js
+	Ti.App.iOS.addEventListener('notification', function(event) {
+	  // Handle foreground notification
+	});
 
-Ti.App.iOS.addEventListener('remotenotificationaction', function(event) {
-  // Handle background notification action click
-});
-```
+	Ti.App.iOS.addEventListener('remotenotificationaction', function(event) {
+	  // Handle background notification action click
+	});
+	```
 
-##### `didRefreshRegistrationToken`
+`didRefreshRegistrationToken`
   - `fcmToken` (String)
+
+`error` (Android only)
+  - `error` (String): Error during token registration
 
 ## Example
 ```js

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -5,28 +5,28 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.media.RingtoneManager;
+import android.net.Uri;
 import android.os.Build;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
-import java.util.HashMap;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import org.appcelerator.kroll.KrollDict;
-import java.util.concurrent.atomic.AtomicInteger;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import java.util.Random;
+import java.io.BufferedInputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.io.BufferedInputStream;
-import org.appcelerator.titanium.util.TiRHelper;
+import java.util.HashMap;
 import java.util.Map;
-import org.json.JSONObject;
-import org.appcelerator.titanium.util.TiConvert;
-import org.appcelerator.titanium.TiApplication;
-import android.net.Uri;
-import android.media.RingtoneManager;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import me.leolin.shortcutbadger.ShortcutBadger;
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiRHelper;
+import org.json.JSONObject;
 
 public class TiFirebaseMessagingService extends FirebaseMessagingService
 {
@@ -35,7 +35,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 	private static final AtomicInteger atomic = new AtomicInteger(0);
 
 	@Override
-	public void onNewToken(String s) {
+	public void onNewToken(String s)
+	{
 		super.onNewToken(s);
 		CloudMessagingModule module = CloudMessagingModule.getInstance();
 		if (module != null) {
@@ -142,10 +143,15 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			}
 		}
 
-		if (params.get("sound") != null && params.get("sound") != "") {
+		if (params.get("sound") != null && params.get("sound") != "" && !params.get("sound").isEmpty()) {
 			int resource = getResource("raw", params.get("sound"));
-			defaultSoundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resource);
-			Log.d(TAG, "custom sound: " + defaultSoundUri);
+			if (resource != 0) {
+				defaultSoundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resource);
+				Log.d(TAG, "custom sound: " + defaultSoundUri);
+			} else {
+				Log.d(TAG, "custom sound not found");
+				builder_defaults |= Notification.DEFAULT_SOUND;
+			}
 		} else {
 			builder_defaults |= Notification.DEFAULT_SOUND;
 		}


### PR DESCRIPTION
* don't show an error when sending an empty sound (#88)
* add `error` event for Android 
* Update Readme (installation notes, XML part, clean up bullet points)
* clang files

(includes #70, so merge that first)

[Android binary 2.0.3](http://migaweb.de/firebase.cloudmessaging-android-2.0.3.zip)