### PR TITLE
Android: Change deprecated constructor

### DIFF
--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -168,7 +168,16 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		// Start building notification
 
-		NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+		NotificationCompat.Builder builder;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			String channelId = "default";
+			if (params.get("channelId") != null && params.get("channelId") != "") {
+				channelId = params.get("channelId");
+			}
+			builder = new NotificationCompat.Builder(context, channelId);
+		} else {
+			builder = new NotificationCompat.Builder(context);
+		}
 		builder.setContentIntent(contentIntent);
 		builder.setAutoCancel(true);
 		builder.setPriority(priority);
@@ -182,13 +191,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		builder.setTicker(params.get("ticker"));
 		builder.setDefaults(builder_defaults);
 		builder.setSound(defaultSoundUri);
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			if (params.get("channelId") != null && params.get("channelId") != "") {
-				builder.setChannelId(params.get("channelId"));
-			} else {
-				builder.setChannelId("default");
-			}
-		}
 
 		// BigText
 		if (params.get("big_text") != null && params.get("big_text") != "") {

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -290,7 +290,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			try {
 				icon = TiRHelper.getApplicationResource(type + "." + name);
 			} catch (TiRHelper.ResourceNotFoundException ex) {
-				Log.e(TAG, type + "." + name + " not found; make sure it's in platform/android/res/" + type);
+				Log.w(TAG, type + "." + name + " not found; make sure it's in platform/android/res/" + type);
 			}
 		}
 


### PR DESCRIPTION
According to https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder.html#notificationcompat.builder_2 the constructor without channelID is deprecated so using the new one in > Android.O

also changing an error log to a warning since there is a fallback for the icons and the error is misleading 