### PR TITLE
Notification Channel sound uri should not be based on fragile resource ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ Supported notification fields:
 * "tag" => "custom_notification_tag",   // push with the same tag will replace each other
 * "sound" => "string" (e.g. "notification.mp3" will play /platform/android/res/raw/notification.mp3)
 
+### Android: Note for switching between v<=v2.0.2 and >=v2.0.3 if you use notification channels with custom sounds
+With versions prior to 2.0.3 of this module, FirebaseCloudMessaging.createNotificationChannel would create the notification sound uri using the resource id of the sound file in the `res/raw` directory. However, as described in this [android issue](https://issuetracker.google.com/issues/131303134), those resource ids can change to reference different files (or no file) between app versions, and  that happens the notification channel may play a different or no sound than originally intended.
+With version 2.0.3 and later, we now create the uri's using the string filename so that it will not change if resource ids change. So if you are on version <=2.0.2 and are switching to version >=2.0.3, you will want to check if this is a problem for you by installing a test app using version >= 2.0.3 as an upgrade to a previous test app using version <= 2.0.2. Note that you should not uninstall the first app before installing the second app; nor should you reset user data.
+If it is a problem you can workaround by first deleting the existing channel using deleteNotificationChannel, and then recreating the channel with the same settings as before, except with a different id. Don't forget that your push server will need to be version aware and send to this new channel for newer versions of your apps.
+
 ## API
 
 ### `FirebaseCloudMessaging`
@@ -235,6 +240,9 @@ so receive the `gcm.message_id` key from the notification payload instead.
   - `showBadge` (Boolean) optional, defaults to `false`
 
   Read more in the [official Android docs](https://developer.android.com/reference/android/app/NotificationChannel).
+
+`deleteNotificationChannel(channelId)` - Android-only
+  - `channelId` (String) - same as the id used to create in createNotificationChannel
 
 `setForceShowInForeground(showInForeground)` - Android-only
   - `showInForeground` (Boolean) Force the notifications to be shown in foreground.

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.2
+version: 2.0.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -10,7 +10,6 @@ package firebase.cloudmessaging;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -216,13 +215,16 @@ public class CloudMessagingModule extends KrollModule
 		if (sound.equals("default") || sound.equals("")) {
 			soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 		} else if (!sound.equals("silent")) {
-			String path = ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/"
-						  + "raw/" + sound;
-			Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + path);
-			soundUri = Uri.parse(path);
+			soundUri = Utils.getSoundUri(sound);
+            Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + soundUri.toString());
 		}
 
-		NotificationChannel channel = new NotificationChannel(channelId, channelName, importanceVal);
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		NotificationChannel channel = notificationManager.getNotificationChannel(channelId);
+		if (channel == null) {
+		    channel = new NotificationChannel(channelId, channelName, importanceVal);
+        }
 		channel.enableVibration(vibration);
 		channel.enableLights(lights);
 		channel.setShowBadge(showBadge);
@@ -233,8 +235,6 @@ public class CloudMessagingModule extends KrollModule
 												  .build();
 			channel.setSound(soundUri, audioAttributes);
 		}
-		NotificationManager notificationManager =
-			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.createNotificationChannel(channel);
 	}
 

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -217,7 +217,7 @@ public class CloudMessagingModule extends KrollModule
 			soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 		} else if (!sound.equals("silent")) {
 			String path = ContentResolver.SCHEME_ANDROID_RESOURCE + "://" + context.getPackageName() + "/"
-						  + Utils.getResourceIdentifier("raw", sound);
+						  + "raw/" + sound;
 			Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + path);
 			soundUri = Uri.parse(path);
 		}
@@ -237,6 +237,20 @@ public class CloudMessagingModule extends KrollModule
 			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.createNotificationChannel(channel);
 	}
+
+	@Kroll.method
+    public void deleteNotificationChannel(String channelId)
+    {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        Log.d(LCAT, "deleteNotificationChannel " + channelId);
+
+        Context context = Utils.getApplicationContext();
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.deleteNotificationChannel(channelId);
+    }
 
 	@Kroll.getProperty
 	public String fcmToken()
@@ -310,9 +324,11 @@ public class CloudMessagingModule extends KrollModule
 	public void parseBootIntent()
 	{
 		try {
+		    Log.d(LCAT, "parseBootIntent");
 			Intent intent = TiApplication.getAppRootOrCurrentActivity().getIntent();
 			String notification = intent.getStringExtra("fcm_data");
 			if (notification != null) {
+			    Log.d(LCAT, "parseBootIntent has notification " + notification);
 				HashMap<String, Object> msg = new HashMap<String, Object>();
 				msg.put("data", new KrollDict(new JSONObject(notification)));
 				onMessageReceived(msg);

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -216,15 +216,15 @@ public class CloudMessagingModule extends KrollModule
 			soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 		} else if (!sound.equals("silent")) {
 			soundUri = Utils.getSoundUri(sound);
-            Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + soundUri.toString());
+			Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + soundUri.toString());
 		}
 
-        NotificationManager notificationManager =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		NotificationManager notificationManager =
+			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		NotificationChannel channel = notificationManager.getNotificationChannel(channelId);
 		if (channel == null) {
-		    channel = new NotificationChannel(channelId, channelName, importanceVal);
-        }
+			channel = new NotificationChannel(channelId, channelName, importanceVal);
+		}
 		channel.enableVibration(vibration);
 		channel.enableLights(lights);
 		channel.setShowBadge(showBadge);
@@ -239,18 +239,18 @@ public class CloudMessagingModule extends KrollModule
 	}
 
 	@Kroll.method
-    public void deleteNotificationChannel(String channelId)
-    {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return;
-        }
-        Log.d(LCAT, "deleteNotificationChannel " + channelId);
+	public void deleteNotificationChannel(String channelId)
+	{
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+			return;
+		}
+		Log.d(LCAT, "deleteNotificationChannel " + channelId);
 
-        Context context = Utils.getApplicationContext();
-        NotificationManager notificationManager =
-                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.deleteNotificationChannel(channelId);
-    }
+		Context context = Utils.getApplicationContext();
+		NotificationManager notificationManager =
+			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		notificationManager.deleteNotificationChannel(channelId);
+	}
 
 	@Kroll.getProperty
 	public String fcmToken()
@@ -324,11 +324,11 @@ public class CloudMessagingModule extends KrollModule
 	public void parseBootIntent()
 	{
 		try {
-		    Log.d(LCAT, "parseBootIntent");
+			Log.d(LCAT, "parseBootIntent");
 			Intent intent = TiApplication.getAppRootOrCurrentActivity().getIntent();
 			String notification = intent.getStringExtra("fcm_data");
 			if (notification != null) {
-			    Log.d(LCAT, "parseBootIntent has notification " + notification);
+				Log.d(LCAT, "parseBootIntent has notification " + notification);
 				HashMap<String, Object> msg = new HashMap<String, Object>();
 				msg.put("data", new KrollDict(new JSONObject(notification)));
 				onMessageReceived(msg);

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -219,12 +219,7 @@ public class CloudMessagingModule extends KrollModule
 			Log.d(LCAT, "createNotificationChannel with sound " + sound + " at " + soundUri.toString());
 		}
 
-		NotificationManager notificationManager =
-			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-		NotificationChannel channel = notificationManager.getNotificationChannel(channelId);
-		if (channel == null) {
-			channel = new NotificationChannel(channelId, channelName, importanceVal);
-		}
+		NotificationChannel channel = new NotificationChannel(channelId, channelName, importanceVal);
 		channel.enableVibration(vibration);
 		channel.enableLights(lights);
 		channel.setShowBadge(showBadge);
@@ -235,6 +230,8 @@ public class CloudMessagingModule extends KrollModule
 												  .build();
 			channel.setSound(soundUri, audioAttributes);
 		}
+		NotificationManager notificationManager =
+			(NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		notificationManager.createNotificationChannel(channel);
 	}
 
@@ -324,11 +321,9 @@ public class CloudMessagingModule extends KrollModule
 	public void parseBootIntent()
 	{
 		try {
-			Log.d(LCAT, "parseBootIntent");
 			Intent intent = TiApplication.getAppRootOrCurrentActivity().getIntent();
 			String notification = intent.getStringExtra("fcm_data");
 			if (notification != null) {
-				Log.d(LCAT, "parseBootIntent has notification " + notification);
 				HashMap<String, Object> msg = new HashMap<String, Object>();
 				msg.put("data", new KrollDict(new JSONObject(notification)));
 				onMessageReceived(msg);

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -64,6 +64,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		CloudMessagingModule module = CloudMessagingModule.getInstance();
 		Boolean appInForeground = TiApplication.isCurrentActivityInForeground();
 		Boolean isVisibile = true;
+		Log.d(TAG, "onMessageReceived " + remoteMessage.getData());
 
 		if (remoteMessage.getData().size() > 0) {
 			// data message
@@ -105,6 +106,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		int priority = NotificationManager.IMPORTANCE_MAX;
 		int builder_defaults = 0;
 
+        Log.d(TAG, "TiFirebaseMessagingService.showNotification " + appInForeground);
+
 		if (appInForeground) {
 			showNotification = false;
 		}
@@ -144,8 +147,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		}
 
 		if (params.get("sound") != null && params.get("sound") != "" && !params.get("sound").isEmpty()) {
-			int resource = getResource("raw", params.get("sound"));
-			if (resource != 0) {
+			String resource = "raw/" + params.get("sound");
+			if (resource != null) {
 				defaultSoundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resource);
 				Log.d(TAG, "custom sound: " + defaultSoundUri);
 			} else {

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -64,7 +64,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		CloudMessagingModule module = CloudMessagingModule.getInstance();
 		Boolean appInForeground = TiApplication.isCurrentActivityInForeground();
 		Boolean isVisibile = true;
-		Log.d(TAG, "onMessageReceived " + remoteMessage.getData());
 
 		if (remoteMessage.getData().size() > 0) {
 			// data message
@@ -105,8 +104,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
 		int priority = NotificationManager.IMPORTANCE_MAX;
 		int builder_defaults = 0;
-
-		Log.d(TAG, "TiFirebaseMessagingService.showNotification " + appInForeground);
 
 		if (appInForeground) {
 			showNotification = false;

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -106,7 +106,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		int priority = NotificationManager.IMPORTANCE_MAX;
 		int builder_defaults = 0;
 
-        Log.d(TAG, "TiFirebaseMessagingService.showNotification " + appInForeground);
+		Log.d(TAG, "TiFirebaseMessagingService.showNotification " + appInForeground);
 
 		if (appInForeground) {
 			showNotification = false;
@@ -147,8 +147,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		}
 
 		if (params.get("sound") != null && params.get("sound") != "" && !params.get("sound").isEmpty()) {
-		    defaultSoundUri = Utils.getSoundUri(params.get("sound"));
-            Log.d(TAG, "showNotification custom sound: " + defaultSoundUri);
+			defaultSoundUri = Utils.getSoundUri(params.get("sound"));
+			Log.d(TAG, "showNotification custom sound: " + defaultSoundUri);
 		} else {
 			builder_defaults |= Notification.DEFAULT_SOUND;
 		}

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -147,14 +147,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		}
 
 		if (params.get("sound") != null && params.get("sound") != "" && !params.get("sound").isEmpty()) {
-			String resource = "raw/" + params.get("sound");
-			if (resource != null) {
-				defaultSoundUri = Uri.parse("android.resource://" + context.getPackageName() + "/" + resource);
-				Log.d(TAG, "custom sound: " + defaultSoundUri);
-			} else {
-				Log.d(TAG, "custom sound not found");
-				builder_defaults |= Notification.DEFAULT_SOUND;
-			}
+		    defaultSoundUri = Utils.getSoundUri(params.get("sound"));
+            Log.d(TAG, "showNotification custom sound: " + defaultSoundUri);
 		} else {
 			builder_defaults |= Notification.DEFAULT_SOUND;
 		}

--- a/android/src/firebase/cloudmessaging/Utils.java
+++ b/android/src/firebase/cloudmessaging/Utils.java
@@ -1,15 +1,15 @@
 package firebase.cloudmessaging;
 
-import android.content.Context;
 import android.content.ContentResolver;
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.Rect;
-import android.graphics.RectF;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.net.Uri;
 import org.appcelerator.titanium.TiApplication;
 
@@ -38,15 +38,15 @@ public final class Utils
 	}
 
 	public static Uri getSoundUri(String name)
-    {
-        Context context = getApplicationContext();
-        return new Uri.Builder()
-                .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
-                .authority(context.getPackageName())
-                .appendPath("raw")
-                .appendPath(name)
-                .build();
-    }
+	{
+		Context context = getApplicationContext();
+		return new Uri.Builder()
+			.scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+			.authority(context.getPackageName())
+			.appendPath("raw")
+			.appendPath(name)
+			.build();
+	}
 
 	public static Context getApplicationContext()
 	{

--- a/android/src/firebase/cloudmessaging/Utils.java
+++ b/android/src/firebase/cloudmessaging/Utils.java
@@ -1,6 +1,7 @@
 package firebase.cloudmessaging;
 
 import android.content.Context;
+import android.content.ContentResolver;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -9,6 +10,7 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import android.net.Uri;
 import org.appcelerator.titanium.TiApplication;
 
 public final class Utils
@@ -34,6 +36,17 @@ public final class Utils
 
 		return icon;
 	}
+
+	public static Uri getSoundUri(String name)
+    {
+        Context context = getApplicationContext();
+        return new Uri.Builder()
+                .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+                .authority(context.getPackageName())
+                .appendPath("raw")
+                .appendPath(name)
+                .build();
+    }
 
 	public static Context getApplicationContext()
 	{


### PR DESCRIPTION
I use custom push sounds in my application and therefore create different notification channels for each sound. On Android Q, I am encountering the following  [documented problem](https://issuetracker.google.com/issues/131303134) when my app upgrades. I have tried the solution documented [here](https://monzo.com/blog/2019/05/28/fixing-notifications-on-android]) but it doesn’t actually fix my problem due to the fact that when you [delete notification channels](https://developer.android.com/reference/android/app/NotificationManager.html#deleteNotificationChannel(java.lang.String)) and recreate them with the same id, it uses the same sound settings it had before it was deleted. So in the current released version of my app, the sound uri’s are based on the fragile resource ids since I use this module to create notification channels.

For me the best solution for me is to create new channels with new ids and that use sound uri’s that reference the raw filename rather than the resource ids in the next version of my app. I can use those same channel ids going forward because once you create the Notification Channels with the non-resource id based uri’s, they are resilient to any changes to the resource ids. To implement this in my app, I had to make a custom version of the module. I would like these changes to be in the source module, so I’m opening this pull request.

I understand that you may want to just deprecate the createNotificationChannel function and wait for titanium to add a deleteNotificationChannel proxy to the android function (I opened a [ticket](https://jira.appcelerator.org/browse/AC-6407) with them asking for this feature), so that this can be a handled entirely by the client. (You would still need the update to use the string based sound uri in TiFirebaseMsgService.showNotification).
