### PR TITLE
Android: use SharedPrefs for lastData

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Supported notification fields:
 * "sound" => "string" (e.g. "notification.mp3" will play /platform/android/res/raw/notification.mp3)
 
 ### Android: Note about custom sounds
-To use a custom sound > Android O you need to create a second channel. The default channel will always use the default notification sound on the device! 
+To use a custom sound > Android O you need to create a second channel. The default channel will always use the default notification sound on the device!
 
 ### Android: Note for switching between v<=v2.0.2 and >=v2.0.3 if you use notification channels with custom sounds
 With versions prior to 2.0.3 of this module, FirebaseCloudMessaging.createNotificationChannel would create the notification sound uri using the resource id of the sound file in the `res/raw` directory. However, as described in this [android issue](https://issuetracker.google.com/issues/131303134), those resource ids can change to reference different files (or no file) between app versions, and  that happens the notification channel may play a different or no sound than originally intended.
@@ -261,7 +261,7 @@ so receive the `gcm.message_id` key from the notification payload instead.
 `apnsToken` (String, set) (iOS only)
 
 `lastData` (Object) (Android only)
-The propery `lastData` will contain the data part when you send a notification push message (so both nodes are visible inside the push payload).
+The propery `lastData` will contain the data part when you send a notification push message (so both nodes are visible inside the push payload). Read before calling `registerForPushNotifications()`.
 
 #### Events
 
@@ -331,8 +331,14 @@ if (OS_ANDROID) {
         showBadge: true
     });
     // if you use a custom id you have to set the same to the `channelId` in you php send script!
-    
+
     fcm.notificationChannel = channel;
+}
+
+
+if (OS_ANDROID){
+    // display last data:
+    Ti.API.info("Last data: " + fcm.lastData);
 }
 
 // Register the device with the FCM service.
@@ -347,11 +353,6 @@ if (fcm.fcmToken) {
 
 // Subscribe to a topic.
 fcm.subscribeToTopic('testTopic');
-
-if (OS_ANDROID){
-    // display last data:
-    Ti.API.info("Last data: " + fcm.lastData);
-}
 ```
 
 ## Send FCM messages with PHP

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.0.3
+version: 2.0.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -344,5 +344,9 @@ public class CloudMessagingModule extends KrollModule
 		} catch (Exception ex) {
 			Log.e(LCAT, "parseBootIntent" + ex);
 		}
+
+		SharedPreferences preferences = Utils.getApplicationContext().getSharedPreferences(
+			"fcm_data", Utils.getApplicationContext().MODE_PRIVATE);
+		preferences.edit().clear().commit();
 	}
 }

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -83,6 +83,16 @@ public class CloudMessagingModule extends KrollModule
 					data.put("inBackground", true);
 				}
 			}
+
+			if (data.get("message") == null) {
+				SharedPreferences preferences = Utils.getApplicationContext().getSharedPreferences(
+					"fcm_data", Utils.getApplicationContext().MODE_PRIVATE);
+				String prefMessage = preferences.getString("message", null);
+				if (prefMessage != null) {
+					data.put("message", new KrollDict(new JSONObject(prefMessage)));
+				}
+				preferences.edit().clear().commit();
+			}
 		} catch (Exception ex) {
 			Log.e(LCAT, "getLastData" + ex);
 		}

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -87,7 +87,7 @@ public class CloudMessagingModule extends KrollModule
 			if (data.get("message") == null) {
 				SharedPreferences preferences = Utils.getApplicationContext().getSharedPreferences(
 					"fcm_data", Utils.getApplicationContext().MODE_PRIVATE);
-				String prefMessage = preferences.getString("message", null);
+				String prefMessage = preferences.getString("titanium.firebase.cloudmessaging.message", null);
 				if (prefMessage != null) {
 					data.put("message", new KrollDict(new JSONObject(prefMessage)));
 				}

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -85,8 +85,8 @@ public class CloudMessagingModule extends KrollModule
 			}
 
 			if (data.get("message") == null) {
-				SharedPreferences preferences = Utils.getApplicationContext().getSharedPreferences(
-					"fcm_data", Utils.getApplicationContext().MODE_PRIVATE);
+				SharedPreferences preferences =
+					PreferenceManager.getDefaultSharedPreferences(Utils.getApplicationContext());
 				String prefMessage = preferences.getString("titanium.firebase.cloudmessaging.message", null);
 				if (prefMessage != null) {
 					data.put("message", new KrollDict(new JSONObject(prefMessage)));
@@ -345,8 +345,7 @@ public class CloudMessagingModule extends KrollModule
 			Log.e(LCAT, "parseBootIntent" + ex);
 		}
 
-		SharedPreferences preferences = Utils.getApplicationContext().getSharedPreferences(
-			"fcm_data", Utils.getApplicationContext().MODE_PRIVATE);
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(Utils.getApplicationContext());
 		preferences.edit().clear().commit();
 	}
 }

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -5,6 +5,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
@@ -149,6 +150,11 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 		} else {
 			builder_defaults |= Notification.DEFAULT_SOUND;
 		}
+
+		SharedPreferences preferences = getSharedPreferences("fcm_data", getApplicationContext().MODE_PRIVATE);
+		SharedPreferences.Editor editor = preferences.edit();
+		editor.putString("message", jsonData.toString());
+		editor.commit();
 
 		if (!showNotification) {
 			// hidden notification - still send broadcast with data for next app start

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -11,6 +11,7 @@ import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import com.google.firebase.messaging.FirebaseMessagingService;
@@ -151,7 +152,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			builder_defaults |= Notification.DEFAULT_SOUND;
 		}
 
-		SharedPreferences preferences = getSharedPreferences("fcm_data", getApplicationContext().MODE_PRIVATE);
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
 		SharedPreferences.Editor editor = preferences.edit();
 		editor.putString("titanium.firebase.cloudmessaging.message", jsonData.toString());
 		editor.commit();

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -153,7 +153,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		SharedPreferences preferences = getSharedPreferences("fcm_data", getApplicationContext().MODE_PRIVATE);
 		SharedPreferences.Editor editor = preferences.edit();
-		editor.putString("message", jsonData.toString());
+		editor.putString("titanium.firebase.cloudmessaging.message", jsonData.toString());
 		editor.commit();
 
 		if (!showNotification) {


### PR DESCRIPTION
More reliable way to use lastData on Android: using shared preferences to store the data when they arrive and read them out when calling lastData

```
var win = Ti.UI.createWindow({});
var fc = require('firebase.core');
var fcm = require('firebase.cloudmessaging');
fc.configure();

fcm.createNotificationChannel({
	channelId: 'default',
	channelName: 'default',
	sound: 'notification',
	importance: 'high',
	vibrate: true,
	lights: true,
	showBadge: true
});

fcm.addEventListener("didRefreshRegistrationToken", onToken);
fcm.addEventListener("didReceiveMessage", onMessage);
fcm.registerForPushNotifications();

console.log('FCM-Token: ' + fcm.fcmToken);

function onToken(e) {
	console.log(e.fcmToken);
}

function onMessage(e) {
	console.log("Got message: " + JSON.stringify(e.message));
	alert("Got message: " + JSON.stringify(e.message.data));
}

function checkIntent() {
	var lastData = fcm.lastData;
	if (lastData.message != null) {
		console.log("fcm lastData: ", JSON.stringify(lastData));
		alert("fcm lastData: " + JSON.stringify(lastData));
	}
}

win.addEventListener("open", function() {
	checkIntent()
	if (this.activity) {
		this.activity.onResume = function() {
			checkIntent()
		};
	} else {
		Ti.App.addEventListener("resumed", function() {
			checkIntent()
		});
	}
});

win.open();
```

Test:
* add firebase configuration
* run the app in background and force-closed
* send data push (e.g. a silent push without title and message)
* restart app using the app icon
* alert is visible with push data

[Test version 2.0.4](http://migaweb.de/firebase.cloudmessaging-android-2.0.4.zip)