### PR TITLE
fix: attempt to fix V8 instance issue in SDK 9

### DIFF
--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -55,7 +55,15 @@ public class CloudMessagingModule extends KrollModule
 	@Kroll.onAppCreate
 	public static void onAppCreate(TiApplication app)
 	{
-		// put module init code that needs to run when the application is created
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(Utils.getApplicationContext());
+		CloudMessagingModule module = CloudMessagingModule.getInstance();
+
+		String cachedToken = preferences.getString("titanium.firebase.cloudmessaging.cached_token", null);
+
+		if (cachedToken != null) {
+			instance.onTokenRefresh(cachedToken);
+			preferences.edit().clear().commit();
+		}
 	}
 
 	// clang-format off
@@ -317,10 +325,7 @@ public class CloudMessagingModule extends KrollModule
 
 	public static CloudMessagingModule getInstance()
 	{
-		if (instance != null)
-			return instance;
-		else
-			return new CloudMessagingModule();
+		return instance;
 	}
 
 	public void setNotificationData(String data)

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -40,10 +40,18 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 	public void onNewToken(String s)
 	{
 		super.onNewToken(s);
+
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(Utils.getApplicationContext());
 		CloudMessagingModule module = CloudMessagingModule.getInstance();
+
 		if (module != null) {
 			module.onTokenRefresh(s);
+			preferences.edit().clear().commit();
+		} else {
+			preferences.setString("titanium.firebase.cloudmessaging.cached_token", s);
+			preferences.edit().commit();
 		}
+
 		Log.d(TAG, "New token: " + s);
 	}
 


### PR DESCRIPTION
An attempt to fix the initial SDK 9 crash when initiating the module. There might be an issue because I check for the token inside a static method, but if we can find an instance method thats called when the V8 engine is ready, we can place the logic in there.

cc @jquick-axway