### PR TITLE
Check for "alert" param

### DIFF
--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -123,8 +123,15 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 			builder_defaults |= Notification.DEFAULT_VIBRATE;
 		}
 
-		if (params.get("title") == null && params.get("message") == null && params.get("big_text") == null
-			&& params.get("big_text_summary") == null && params.get("ticker") == null && params.get("image") == null) {
+		if (
+			params.get("title") == null &&
+			params.get("message") == null &&
+			params.get("alert") == null &&
+			params.get("big_text") == null &&
+			params.get("big_text_summary") == null &&
+			params.get("ticker") == null &&
+			params.get("image") == null
+		) {
 			// no actual content - don't show it
 			showNotification = false;
 		}


### PR DESCRIPTION
It is noted when setting the content text that OneSignal uses alert for the message. In my case, "Alert" is the only parameter sent by Parse Dashboard, so the notification is not shown.

I've added a check for the "alert" param along with the other content checks.

The statements were getting a bit unwieldy and hard to read, so I split them into separate lines.

It is worth noting that I haven't been able to build the module for testing yet; I get an error that `package com.google.android.gms.tasks does not exist`. I figure this is such a small change that I should open the pull request first while I attempt to sort out the dependencies.