### PR TITLE
fix(android): fix crash on first app launch, update firebase-messaging to 20.1.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,5 +6,4 @@ repositories {
 dependencies {
 	implementation "androidx.preference:preference:1.1.0"
 	implementation 'com.google.firebase:firebase-messaging:20.1.6'
-	implementation "me.leolin:ShortcutBadger:1.1.22@aar"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,6 @@ repositories {
 
 dependencies {
 	implementation "androidx.preference:preference:1.1.0"
-	compile 'com.google.firebase:firebase-messaging:20.0.1'
+	implementation 'com.google.firebase:firebase-messaging:20.1.6'
 	implementation "me.leolin:ShortcutBadger:1.1.22@aar"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,5 +5,6 @@ repositories {
 
 dependencies {
 	implementation "androidx.preference:preference:1.1.0"
+	implementation "me.leolin:ShortcutBadger:1.1.22@aar"
 	implementation 'com.google.firebase:firebase-messaging:20.1.6'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -314,10 +314,7 @@ public class CloudMessagingModule extends KrollModule
 
 	public static CloudMessagingModule getInstance()
 	{
-		if (instance != null)
-			return instance;
-		else
-			return new CloudMessagingModule();
+		return instance;
 	}
 
 	public void setNotificationData(String data)

--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -21,7 +21,11 @@ public class PushHandlerActivity extends Activity
 			CloudMessagingModule module = CloudMessagingModule.getInstance();
 			Context context = getApplicationContext();
 			String notification = getIntent().getStringExtra("fcm_data");
-			module.setNotificationData(notification);
+
+			if (module != null) {
+				module.setNotificationData(notification);
+			}
+
 			Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
 			launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
 			launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -12,6 +12,7 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.util.Log;
+
 import androidx.core.app.NotificationCompat;
 import androidx.preference.PreferenceManager;
 import com.google.firebase.messaging.FirebaseMessagingService;
@@ -23,7 +24,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
-import me.leolin.shortcutbadger.ShortcutBadger;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
@@ -32,7 +32,6 @@ import org.json.JSONObject;
 
 public class TiFirebaseMessagingService extends FirebaseMessagingService
 {
-
 	private static final String TAG = "FirebaseMsgService";
 	private static final AtomicInteger atomic = new AtomicInteger(0);
 
@@ -270,7 +269,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		// Badge number
 		if (params.get("badge") != null && params.get("badge") != "") {
-			ShortcutBadger.applyCount(context, TiConvert.toInt(params.get("badge"), 1));
 			builder.setNumber(TiConvert.toInt(params.get("badge"), 1));
 		}
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import me.leolin.shortcutbadger.ShortcutBadger;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
@@ -273,6 +274,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		// Badge number
 		if (params.get("badge") != null && params.get("badge") != "") {
+			ShortcutBadger.applyCount(context, TiConvert.toInt(params.get("badge"), 1));
 			builder.setNumber(TiConvert.toInt(params.get("badge"), 1));
 		}
 


### PR DESCRIPTION
Fixes an issue where the app crashes on the first launch after the install by performing proper null-checks on the instance instead of forcing to re-instantiate the module.

Also bumps the version of `firebase-messaging` to `20.1.6`.

[firebase.cloudmessaging-android-3.0.1.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/4573670/firebase.cloudmessaging-android-3.0.1.zip)
