### PR TITLE
fix(android): set exported value

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.2.0
+version: 3.2.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -6,7 +6,7 @@
 			<uses-permission android:name="android.permission.WAKE_LOCK"/>
 			<uses-permission android:name="android.permission.VIBRATE"/>
 			<application>
-				<service android:name="firebase.cloudmessaging.TiFirebaseMessagingService">
+				<service android:name="firebase.cloudmessaging.TiFirebaseMessagingService" android:exported="true">
 					<intent-filter>
 						<action android:name="com.google.firebase.MESSAGING_EVENT"/>
 					</intent-filter>


### PR DESCRIPTION
https://github.com/hansemannn/titanium-firebase-cloud-messaging/issues/130

add missing exported value to make it Android 12 safe