### PR TITLE
feat(android): remove core requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ thank you!
 * [Build from source](#build)
 
 ## Requirements
-- [x] The [Firebase Core](https://github.com/hansemannn/titanium-firebase-core) module.
-The options `googleAppID` and `GCMSenderID` are required for Android, or `file` (e.g. `GoogleService-Info.plist`) for iOS.
 - [x] iOS: Titanium SDK 7.3.0+ (if you use SDK < 7.3.0, please use Ti.FirebaseCloudMessaging v1.1.0)
 - [x] Android: Titanium SDK 7.0.0+, [Ti.PlayServices](https://github.com/appcelerator-modules/ti.playservices) module
-- [x] Read the [Firebase-Core](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
+- [x] Read the [Titanium-Firebase](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
 
 
 ## Download
@@ -91,42 +89,6 @@ Big text notification with colored icon/appname
 
 
 ### Updates to the Manifest
-
-Merge the following keys to the `<android>` section of the tiapp.xml in order to use GCM (not needed for FCM).
-
-```xml
-<android xmlns:android="http://schemas.android.com/apk/res/android">
-    <manifest>
-    <application>
-    <service android:name="MY_PACKAGE_NAME.gcm.RegistrationIntentService" android:exported="false" />
-
-    <receiver android:name="com.google.android.gms.measurement.AppMeasurementReceiver" android:enabled="true">
-       <intent-filter>
-      <action android:name="com.google.android.gms.measurement.UPLOAD" />
-       </intent-filter>
-    </receiver>  
-
-    <service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
-       <intent-filter>
-      <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-       </intent-filter>
-    </service>
-
-    <service android:name="MY_PACKAGE_NAME.gcm.GcmIntentService" android:exported="false">
-       <intent-filter>
-      <action android:name="com.google.android.c2dm.intent.SEND" />
-       </intent-filter>
-    </service>
-
-    <service android:name="MY_PACKAGE_NAME.gcm.GcmIDListenerService" android:exported="false">
-       <intent-filter>
-      <action android:name="com.google.android.gms.iid.InstanceID" />
-       </intent-filter>
-    </service>
-    </application>
-    </manifest>
-</android>   
-```
 
 If you run into errors in combination with firebase.analytics e.g. `Error: Attempt to invoke virtual method 'getInstanceId()' on a null object reference` you can add:
 
@@ -332,12 +294,6 @@ The propery `lastData` will contain the data part when you send a notification p
 Full example for Android/iOS:
 
 ```js
-// Import core module
-var core = require('firebase.core');
-
-// Configure core module (required for all Firebase modules).
-core.configure();
-
 // Important: The cloud messaging module has to imported after (!) the configure()
 // method of the core module is called
 var fcm = require('firebase.cloudmessaging');
@@ -565,10 +521,6 @@ ti build -p ios --build-only
 ```
 
 ### Android
-
-> **Note**: When building for Android, make sure you have the [firebase.core](https://github.com/hansemannn/titanium-firebase-core) module installed globally (`~/Library/Application Support/Titanium/modules/android/firebase.core`). Otherwise, the firebase-iid library will not be referenced properly.
-
-Find the latest library version at https://firebase.google.com/docs/android/learn-more#compare-bom-versions
 
 ```bash
 cd android

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ thank you!
 * [Build from source](#build)
 
 ## Requirements
-- [x] iOS: Titanium SDK 7.3.0+ (if you use SDK < 7.3.0, please use Ti.FirebaseCloudMessaging v1.1.0)
+- [x] iOS: [Firebase-Core](https://github.com/hansemannn/titanium-firebase-core)
+- [x] iOS: Titanium SDK 7.3.0+
 - [x] Android: Titanium SDK 7.0.0+, [Ti.PlayServices](https://github.com/appcelerator-modules/ti.playservices) module
 - [x] Read the [Titanium-Firebase](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
 
@@ -41,7 +42,7 @@ thank you!
 </tr>
 </table>
 
-To register for push notifications on iOS, startin in 2.0.0, you only need to call the Titanium related methods as the following:
+To register for push notifications on iOS, you only need to call the Titanium related methods as the following:
 ```js
 // Listen to the notification settings event
 Ti.App.iOS.addEventListener('usernotificationsettings', function eventUserNotificationSettings() {
@@ -294,6 +295,12 @@ The propery `lastData` will contain the data part when you send a notification p
 Full example for Android/iOS:
 
 ```js
+
+if (OS_IOS) {
+  var fc = require("firebase.core");
+  fc.configure();
+}
+
 // Important: The cloud messaging module has to imported after (!) the configure()
 // method of the core module is called
 var fcm = require('firebase.cloudmessaging');

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 	implementation "me.leolin:ShortcutBadger:1.1.22@aar"
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
-	implementation 'com.google.firebase:firebase-messaging:22.0.0'
+	implementation 'com.google.firebase:firebase-messaging:23.0.0'
 }

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Mar 31 20:21:59 CEST 2020
-sdk.dir=/home/miga/tools/Android/sdk

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.2.2
+version: 3.3.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -177,7 +177,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService
 
 		int requestCode = (int)(System.currentTimeMillis() / 1000);
 		PendingIntent contentIntent =
-			PendingIntent.getActivity(this, requestCode, notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+			PendingIntent.getActivity(this, requestCode, notificationIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT);
 
 		// Start building notification
 

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -16,9 +16,6 @@
 		</manifest>
 	</android>
 	<modules>
-		<!-- Require Firebase Core (https://github.com/hansemannn/titanium-firebase-core) -->
-		<module>firebase.core</module>
-
 		<!-- Require Ti.PlayServices (https://github.com/appcelerator-modules/ti.playservices) -->
 		<module platform="android">ti.playservices</module>
 	</modules>


### PR DESCRIPTION
* Remove firebase.core as a requirement since it will include AdMob (even if it is not used).
According to Google: https://firebase.google.com/support/release-notes/android it is not needed anymore.
> The Firebase Android library firebase-core is no longer needed. This SDK included the Firebase SDK for Google Analytics.



* Raised the fcm version
> Added methods for determining and controlling whether Google Play services is set as the app’s notification delegate. By default, FCM will now set Google Play services as the app’s notification delegate so that it is allowed to display notifications for the app. This could be used in the future to show an app’s notifications without needing to start the app, which may improve message reliability and timeliness.

Couldn't find any anything in the documentation but it still works so why not update it :smile: 


* added FLAG_IMMUTABLE to fix `Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.`

**Tests**
I did test fcm, analytics, performance, crash, auth without core and they work. So we can remove the requirement from timodule.xml too

**iOS**
<strike>I didn't test iOS yet and don't know if it is still needed there.</strike> Still has to be there. Added it back to the readme.


[firebase.cloudmessaging-android-3.3.0.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/7776160/firebase.cloudmessaging-android-3.3.0.zip)


