### PR TITLE
fix(android): change intent category

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.3.0
+version: 3.3.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -28,7 +28,7 @@ public class PushHandlerActivity extends Activity
 
 			Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
 			assert launcherIntent != null;
-			launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+			launcherIntent.addCategory(Intent.ACTION_MAIN);
 			launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 			launcherIntent.putExtra("fcm_data", notification);
 


### PR DESCRIPTION
Change the launcher category from `Intent.CATEGORY_LAUNCHER` to `Intent.ACTION_MAIN`. This will trigger 
```js
var message = Titanium.Android.currentActivity.intent.getStringExtra("fcm_data");
console.log("intent string extra: ", message);
```
when the app was in the background (still running) and you click on the notification. Before it was empty unless the app was closed.
[firebase.cloudmessaging-android-3.3.1.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/8098119/firebase.cloudmessaging-android-3.3.1.zip)

