### PR TITLE
feat(android): minor dep update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.0.5'
+	implementation 'com.google.firebase:firebase-messaging:23.0.7'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,5 +8,6 @@ dependencies {
 	implementation "me.leolin:ShortcutBadger:1.1.22@aar"
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
-	implementation 'com.google.firebase:firebase-messaging:23.0.0'
+	// changelog https://firebase.google.com/support/release-notes/android
+	implementation 'com.google.firebase:firebase-messaging:23.0.5'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.3.0
+version: 3.3.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging


### PR DESCRIPTION
Minor firebase library update (23.0.0 -> 23.0.7):

* https://firebase.google.com/support/release-notes/android#messaging_v23-0-7 (`This change should reduce the chance of ANRs.`)
* https://firebase.google.com/support/release-notes/android#messaging_v23-0-6 (`Added the POST_NOTIFICATIONS permission to enable posting notifications when targeting SDK level 33`, did the same in the #141 )
* https://firebase.google.com/support/release-notes/android#messaging_v23-0-5
* https://firebase.google.com/support/release-notes/android#messaging_v23-0-3
* https://firebase.google.com/support/release-notes/android#messaging_v23-0-2
* https://firebase.google.com/support/release-notes/android#messaging_v23-0-1


[firebase.cloudmessaging-android-3.3.1.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/9373754/firebase.cloudmessaging-android-3.3.1.zip)

