### PR TITLE
feat(android): update library, change intent category, clear data

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.0.7'
+	implementation 'com.google.firebase:firebase-messaging:23.1.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.3.1
+version: 3.4.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -76,7 +76,14 @@ public class CloudMessagingModule extends KrollModule {
 
             if (extras != null) {
                 for (String key : extras.keySet()) {
-                    data.put(key, extras.get(key));
+                    if (extras.get(key) instanceof Bundle) {
+                        Bundle bndl = (Bundle) extras.get(key);
+                        for (String bdnlKey : bndl.keySet()) {
+                            data.put(key + "_" + bdnlKey, bndl.get(bdnlKey));
+                        }
+                    } else {
+                        data.put(key, extras.get(key).toString());
+                    }
                 }
 
                 data.put("inBackground", true);
@@ -154,8 +161,14 @@ public class CloudMessagingModule extends KrollModule {
     public void clearLastData() {
         SharedPreferences preferences =
                 PreferenceManager.getDefaultSharedPreferences(Utils.getApplicationContext());
-        String prefMessage = preferences.getString("titanium.firebase.cloudmessaging.message", null);
         preferences.edit().remove("titanium.firebase.cloudmessaging.message").apply();
+
+        // remove intent value
+        Intent intent = TiApplication.getAppRootOrCurrentActivity().getIntent();
+        String notification = intent.getStringExtra("fcm_data");
+        if (notification != null) {
+            intent.removeExtra("fcm_data");
+        }
     }
 
     @Kroll.method

--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -26,7 +26,7 @@ public class PushHandlerActivity extends Activity {
 
             Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
             assert launcherIntent != null;
-            launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+            launcherIntent.addCategory(Intent.ACTION_MAIN);
             launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             launcherIntent.putExtra("fcm_data", notification);
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -264,7 +264,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
 
         if (params.get("color") != null && params.get("color") != "") {
             try {
-                int color = TiConvert.toColor(params.get("color"));
+                int color = TiConvert.toColor(params.get("color"), TiApplication.getAppCurrentActivity());
                 builder.setColor(color);
                 builder.setColorized(true);
             } catch (Exception ex) {


### PR DESCRIPTION
Since #137 is used in a client project I've merged all the Android PRs into one

<b>Merge PRs</b>
* change intent category (more infos in #137 )
* fix parse bundle error (more infos in #137 )
* update library (more infos in #145)
* fix `toColor` deprecation warning

<b>New:</b>
* use `clearLastData` to clear intent data too. Otherwise it will show up on every resume


[firebase.cloudmessaging-android-3.4.0.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/11027027/firebase.cloudmessaging-android-3.4.0.zip)
