### PR TITLE
Android version bump

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.1.1'
+	implementation 'com.google.firebase:firebase-messaging:23.1.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.1.2'
+	implementation 'com.google.firebase:firebase-messaging:23.2.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.2.0'
+	implementation 'com.google.firebase:firebase-messaging:23.2.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.4.0
+version: 3.4.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging


### PR DESCRIPTION
Just a minor version bumb to reflect the announced changes in the FCM infrastructure.

From the current mail:
> Take the following actions before June 20, 2024... Android | >= 23.1.2


No major changes in their changelog:
https://firebase.google.com/support/release-notes/android#messaging_v23-1-2
https://firebase.google.com/support/release-notes/android#messaging_v23-2-1

[firebase.cloudmessaging-android-3.4.1.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/12305870/firebase.cloudmessaging-android-3.4.1.zip)



23.2.0:
```
Deprecated FCM upstream messaging. After June 21, 2024, API calls to [FirebaseMessaging.send](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging#send) in the app won’t trigger upstream messages to the app server. For more details, see the [FAQ about FCM features deprecated in June 2023](https://firebase.google.com/support/faq#fcm-23-deprecation).
```