### PR TITLE
fix: (android) fix checkSelfPermission error on android 13+

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.4.1
+version: 3.4.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -117,7 +117,7 @@ public class CloudMessagingModule extends KrollModule {
     @Kroll.method
     public void registerForPushNotifications() {
         if (Build.VERSION.SDK_INT >= 33) {
-            if (TiApplication.getAppCurrentActivity().checkSelfPermission("android.permission.POST_NOTIFICATIONS") == PackageManager.PERMISSION_GRANTED) {
+            if (Utils.getApplicationContext().checkSelfPermission("android.permission.POST_NOTIFICATIONS") == PackageManager.PERMISSION_GRANTED) {
                 fireEvent("success", new KrollDict());
                 getToken();
             } else {


### PR DESCRIPTION
Looking in my Crashlytics console of my production version, i saw a lot of errors like this on Android 13+:

`Attempt to invoke virtual method 'int android.app.Activity.checkSelfPermission(java.lang.String)' on a null object reference(onToken(e):fcm.registerForPushNotifications();:1292)`

When i look for the Titanium code, i see **TiApplication.getAppCurrentActivity()** returns an **Activity**, but on source code from Android, an Activity do not have the _checkSelfPermission_ method on it. 

Searching on google, i found that **Context** have the method implemented.
https://developer.android.com/reference/android/content/Context#checkSelfPermission(java.lang.String)

I tested on my Android 14 device and it works normally to receive tokens and push.

[firebase.cloudmessaging-android-3.4.2.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/15002931/firebase.cloudmessaging-android-3.4.2.zip)