### PR TITLE
android: update to 23.4.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:23.2.1'
+	implementation 'com.google.firebase:firebase-messaging:23.4.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.4.2
+version: 3.4.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging


### PR DESCRIPTION
Changelog:

**23.4.0**
* The SDK now calls messageHandled() after a message has been handled successfully.    
 _(note: couldn't find anything in the help about that)_
* Added an internal identifier to meet compliance requirements.

**23.3.1**

* Added metadata to FirebaseInstanceIdReceiver to signal that it finishes background broadcasts after the message has been handled.
* Specified a notification's dismiss intent target via an action instead of component name.

[firebase.cloudmessaging-android-3.4.3.zip](https://github.com/hansemannn/titanium-firebase-cloud-messaging/files/15094860/firebase.cloudmessaging-android-3.4.3.zip)

