### PR TITLE
feat(android): add notification fields to fcm_data

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.4.2
+version: 3.4.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -181,6 +181,18 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         editor.putString("titanium.firebase.cloudmessaging.message", jsonData.toString());
         editor.commit();
 
+        try {
+            // adding normal notification fields to the fcm_data node
+            if (!remoteMessage.getNotification().getTitle().isEmpty()) {
+                jsonData.put("notification_title", remoteMessage.getNotification().getTitle());
+            }
+            if (!remoteMessage.getNotification().getBody().isEmpty()) {
+                jsonData.put("notification_body", remoteMessage.getNotification().getBody());
+            }
+        } catch (Exception ex) {
+            //
+        }
+
         if (!showNotification) {
             // hidden notification - still send broadcast with data for next app start
             Intent i = new Intent();

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -190,7 +190,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
                 jsonData.put("notification_body", remoteMessage.getNotification().getBody());
             }
         } catch (Exception ex) {
-            //
+            Log.e(TAG, "Error adding fields: " + ex.getMessage());
         }
 
         if (!showNotification) {


### PR DESCRIPTION
If you click on a notification and read the intent data you'll only get the data node at the moment. This PR will add the normal notification title and body to the fcm_data:

```
intent string extra:  {"custom":"foo","priority":"high","color":"#ff0000","title":"value","channelId":"my_channel3","force_show_in_foreground":"true","notification_title":"My title","notification_body":"My Body"}
```

I've used `notification_title` and `notification_body` in case people already use `title` and `body` in their data fields.

[firebase.cloudmessaging-android-3.4.3.zip](https://github.com/user-attachments/files/17257712/firebase.cloudmessaging-android-3.4.3.zip)



Example app: https://github.com/m1ga/ti.fcm.example
or use
```js
	var activity = Ti.Android.currentActivity
		activity.addEventListener("newintent", function(e) {
			var intent = e.intent;
			if (intent.getStringExtra("fcm_data") != "") {
				console.log("New intent:\n" + intent.getStringExtra("fcm_data"));
			}
		});
```
to read the intent data when you click on a notification.