### PR TITLE
chore(android): be able to call Braze Firebase handler, fix warnings

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.5.1
+version: 3.5.2
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/manifest
+++ b/android/manifest
@@ -16,4 +16,4 @@ name: titanium-firebase-cloud-messaging
 moduleid: firebase.cloudmessaging
 guid: 61e63a26-50eb-4ec9-9199-aff987a96a67
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -71,15 +71,15 @@ public class CloudMessagingModule extends KrollModule {
 
             if (extras != null) {
                 for (String key : extras.keySet()) {
-                    if (extras.get(key) instanceof Bundle) {
-                        Bundle bndl = (Bundle) extras.get(key);
-                        for (String bdnlKey : bndl.keySet()) {
-                            data.put(key + "_" + bdnlKey, bndl.get(bdnlKey));
+                    Bundle bundle = extras.getBundle(key);
+                    if (bundle != null) {
+                        for (String bundleKey : bundle.keySet()) {
+                            data.put(key + "_" + bundleKey, bundle.getString(bundleKey));
                         }
                     } else {
-                        Object value = extras.get(key);
+                        String value = extras.getString(key);
                         if (value != null) {
-                            data.put(key, value.toString());
+                            data.put(key, value);
                         }
                     }
                 }
@@ -192,7 +192,12 @@ public class CloudMessagingModule extends KrollModule {
     }
 
     @Kroll.method
+    @SuppressWarnings("deprecation")
     public void sendMessage(KrollDict obj) {
+        Log.e(LCAT, "Deprecated: This function is actually decommissioned along " +
+                "with all of FCM upstream messaging. Learn more in the FAQ about FCM features " +
+                "deprecated in June 2023: https://firebase.google.com/support/faq?hl=de#fcm-23-deprecation");
+
         FirebaseMessaging fm = FirebaseMessaging.getInstance();
 
         String fireTo = obj.getString("to");
@@ -204,10 +209,10 @@ public class CloudMessagingModule extends KrollModule {
         rm.setTtl(ttl);
 
         // add custom data
-        Map<String, String> data = (HashMap) obj.get("data");
-        assert data != null;
-        for (String o : data.keySet()) {
-            rm.addData(o, data.get(o));
+        if (obj.get("data") instanceof Map<?, ?> data) {
+            for (Object o : data.keySet()) {
+                rm.addData((String) o, (String) data.get(o));
+            }
         }
 
         if (!fireTo.isEmpty() && !fireMessageId.isEmpty()) {

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -50,7 +50,18 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         Log.d(TAG, "New token: " + s);
     }
 
-    private boolean callBraze(Context context, RemoteMessage remoteMessage) {
+    /**
+     * Attempts to handle a Firebase Cloud Messaging remote message using the Braze SDK if it's available.
+     * This method uses reflection to dynamically call the Braze SDK's handling method without requiring
+     * a direct dependency on the Braze SDK.
+     * 
+     * @param context The application context to be passed to the Braze handler
+     * @param remoteMessage The Firebase RemoteMessage object to be processed
+     * @return true if the message was successfully handled by Braze, false otherwise
+     */
+    private boolean handleBrazeRemoteMessage(RemoteMessage remoteMessage) {
+        Context context = getApplicationContext();
+
         try {
             return (Boolean) Class.forName("com.braze.push.BrazeFirebaseMessagingService")
                     .getMethod("handleBrazeRemoteMessage", Context.class, RemoteMessage.class)
@@ -64,11 +75,10 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         HashMap<String, Object> msg = new HashMap<>();
-        Context context = getApplicationContext();
         CloudMessagingModule module = CloudMessagingModule.getInstance();
         boolean isVisible = true;
 
-        if (callBraze(context, remoteMessage)) {
+        if (handleBrazeRemoteMessage(remoteMessage)) {
             return;
         }
 
@@ -348,6 +358,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         notificationManager.notify(id, builder.build());
         return true;
     }
+
 
     private Bitmap getBitmapFromURL(String src) throws Exception {
         HttpURLConnection connection = (HttpURLConnection) (new URL(src)).openConnection();

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -55,10 +55,10 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
      * This method uses reflection to dynamically call the Braze SDK's handling method without requiring
      * a direct dependency on the Braze SDK.
      * 
-     * @param context The application context to be passed to the Braze handler
      * @param remoteMessage The Firebase RemoteMessage object to be processed
      * @return true if the message was successfully handled by Braze, false otherwise
      */
+    @SuppressWarnings({"all"})
     private boolean handleBrazeRemoteMessage(RemoteMessage remoteMessage) {
         Context context = getApplicationContext();
 
@@ -97,7 +97,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         }
 
         msg.put("from", remoteMessage.getFrom());
-        msg.put("to", remoteMessage.getTo());
         msg.put("ttl", remoteMessage.getTtl());
         msg.put("messageId", remoteMessage.getMessageId());
         msg.put("messageType", remoteMessage.getMessageType());
@@ -149,10 +148,11 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         }
 
         // Check if it is a default Parse/Sashido message ("data.data.alert")
-        if (params.get("data") != null) {
+        String parseData = params.get("data");
+        if (parseData != null) {
             try {
                 // Parse notification
-                JSONObject localJsonData = new JSONObject(params.get("data"));
+                JSONObject localJsonData = new JSONObject(parseData);
                 parseTitle = localJsonData.get("alert").toString();
                 showNotification = true;
                 isParse = true;
@@ -166,7 +166,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         int priority = 1;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            priority = NotificationManager.IMPORTANCE_MAX;
+            priority = NotificationManager.IMPORTANCE_DEFAULT;
 
             if (!priorityValue.isEmpty()) {
                 if (priorityValue.equalsIgnoreCase("low")) {
@@ -175,8 +175,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
                     priority = NotificationManager.IMPORTANCE_MIN;
                 } else if (priorityValue.equalsIgnoreCase("max")) {
                     priority = NotificationManager.IMPORTANCE_MAX;
-                } else if (priorityValue.equalsIgnoreCase("default")) {
-                    priority = NotificationManager.IMPORTANCE_DEFAULT;
                 } else if (priorityValue.equalsIgnoreCase("high")) {
                     priority = NotificationManager.IMPORTANCE_HIGH;
                 } else {
@@ -218,7 +216,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
 
         if (!showNotification) {
             // hidden notification - still send broadcast with data for next app start
-            Intent i = new Intent();
+            Intent i = new Intent().setAction("ti.firebase.messaging.hidden-notification");
             i.addCategory(Intent.CATEGORY_LAUNCHER);
             i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             i.putExtra("fcm_data", jsonData.toString());

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -359,7 +359,6 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         return true;
     }
 
-
     private Bitmap getBitmapFromURL(String src) throws Exception {
         HttpURLConnection connection = (HttpURLConnection) (new URL(src)).openConnection();
         connection.setDoInput(true);

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -50,11 +50,27 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         Log.d(TAG, "New token: " + s);
     }
 
+    private boolean callBraze(Context context, RemoteMessage remoteMessage) {
+        try {
+            return (Boolean) Class.forName("com.braze.push.BrazeFirebaseMessagingService")
+                    .getMethod("handleBrazeRemoteMessage", Context.class, RemoteMessage.class)
+                    .invoke(null, context, remoteMessage);
+        } catch (Exception e) {
+            Log.e(TAG, e.toString());
+            return false;
+        }
+    }
+
     @Override
-    public void onMessageReceived(RemoteMessage remoteMessage) {
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
         HashMap<String, Object> msg = new HashMap<>();
+        Context context = getApplicationContext();
         CloudMessagingModule module = CloudMessagingModule.getInstance();
         boolean isVisible = true;
+
+        if (callBraze(context, remoteMessage)) {
+            return;
+        }
 
         if (!remoteMessage.getData().isEmpty()) {
             // data message

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -74,6 +74,8 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        super.onMessageReceived(remoteMessage);
+        
         HashMap<String, Object> msg = new HashMap<>();
         CloudMessagingModule module = CloudMessagingModule.getInstance();
         boolean isVisible = true;


### PR DESCRIPTION
This took me a while to figure out - but it allows us to use Braze-related APIs without linking the libraries for users that don't use Braze.

In addition, this PR fixes all warnings.