### PR TITLE
android: hidden notification when in background

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.5.3
+version: 3.5.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -123,6 +123,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
         String parseTitle = "";
         String parseText = "";
         boolean isParse = false;
+        boolean noContent = false;
 
         if ( TiApplication.isCurrentActivityInForeground()) {
             showNotification = false;
@@ -145,7 +146,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
                 && params.get("big_text") == null && params.get("big_text_summary") == null && params.get("ticker") == null
                 && params.get("image") == null) {
             // no actual content - don't show it
-            showNotification = false;
+            noContent = true;
         }
 
         // Check if it is a default Parse/Sashido message ("data.data.alert")
@@ -215,14 +216,14 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
             Log.e(TAG, "Error adding fields: " + ex.getMessage());
         }
 
-        if (!showNotification) {
+        if (noContent) {
             // hidden notification - still send broadcast with data for next app start
             Intent i = new Intent().setAction("ti.firebase.messaging.hidden-notification");
             i.addCategory(Intent.CATEGORY_LAUNCHER);
             i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             i.putExtra("fcm_data", jsonData.toString());
             sendBroadcast(i);
-            return false;
+            return true;
         }
 
         Intent notificationIntent = new Intent(this, PushHandlerActivity.class);


### PR DESCRIPTION
**Current behavior:**

when you send a **data notification** without a `title` it will handle it as a "hidden" notification and only set an intent for the next app start (as there is no notification). BUT if the app is still running in the background it should still trigger `didReceiveMessage`. Currently it doesn't as we set `showNotification = false`.

**This PR:**

Will return `true` so it still tries to call `didReceiveMessage` but still sets the `ti.firebase.messaging.hidden-notification` in case it was closed.


Testing it with a Slack user at the moment

[firebase.cloudmessaging-android-3.5.4.zip](https://github.com/user-attachments/files/20298421/firebase.cloudmessaging-android-3.5.4.zip)

**Test:**
* create a push project
* start the app and put it into the background
* send a data notification without a title attribute
* check if `didReceiveMessage` is called
