### PR TITLE
Android: update library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:25.0.1'
+	implementation 'com.google.firebase:firebase-messaging:25.0.2'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,5 +9,5 @@ dependencies {
 
 	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
 	// changelog https://firebase.google.com/support/release-notes/android
-	implementation 'com.google.firebase:firebase-messaging:24.1.0'
+	implementation 'com.google.firebase:firebase-messaging:25.0.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 
-version: 3.5.4
+version: 4.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-cloud-messaging
@@ -16,4 +16,4 @@ name: titanium-firebase-cloud-messaging
 moduleid: firebase.cloudmessaging
 guid: 61e63a26-50eb-4ec9-9199-aff987a96a67
 platform: android
-minsdk: 12.7.0
+minsdk: 13.0.0

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -191,37 +191,6 @@ public class CloudMessagingModule extends KrollModule {
         });
     }
 
-    @Kroll.method
-    @SuppressWarnings("deprecation")
-    public void sendMessage(KrollDict obj) {
-        Log.e(LCAT, "Deprecated: This function is actually decommissioned along " +
-                "with all of FCM upstream messaging. Learn more in the FAQ about FCM features " +
-                "deprecated in June 2023: https://firebase.google.com/support/faq?hl=de#fcm-23-deprecation");
-
-        FirebaseMessaging fm = FirebaseMessaging.getInstance();
-
-        String fireTo = obj.getString("to");
-        String fireMessageId = obj.getString("messageId");
-        int ttl = TiConvert.toInt(obj.get("timeToLive"), 0);
-
-        RemoteMessage.Builder rm = new RemoteMessage.Builder(fireTo);
-        rm.setMessageId(fireMessageId);
-        rm.setTtl(ttl);
-
-        // add custom data
-        if (obj.get("data") instanceof Map<?, ?> data) {
-            for (Object o : data.keySet()) {
-                rm.addData((String) o, (String) data.get(o));
-            }
-        }
-
-        if (!fireTo.isEmpty() && !fireMessageId.isEmpty()) {
-            fm.send(rm.build());
-        } else {
-            Log.e(LCAT, "Please set 'to' and 'messageId'");
-        }
-    }
-
     public void onTokenRefresh(String token) {
         try {
             if (hasListeners("didRefreshRegistrationToken")) {

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -77,7 +77,7 @@ public class CloudMessagingModule extends KrollModule {
                             data.put(key + "_" + bundleKey, bundle.getString(bundleKey));
                         }
                     } else {
-                        String value = extras.getString(key);
+                        String value = extras.getString(TiConvert.toString(key));
                         if (value != null) {
                             data.put(key, value);
                         }

--- a/android/src/firebase/cloudmessaging/CloudMessagingModule.java
+++ b/android/src/firebase/cloudmessaging/CloudMessagingModule.java
@@ -60,6 +60,7 @@ public class CloudMessagingModule extends KrollModule {
     // clang-format off
     @Kroll.method
     @Kroll.getProperty
+    @SuppressWarnings("deprecation")
     private KrollDict getLastData()
     // clang-format on
     {
@@ -71,16 +72,14 @@ public class CloudMessagingModule extends KrollModule {
 
             if (extras != null) {
                 for (String key : extras.keySet()) {
-                    Bundle bundle = extras.getBundle(key);
-                    if (bundle != null) {
+                    Object value = extras.get(key);
+                    if (value instanceof Bundle) {
+                        Bundle bundle = (Bundle) value;
                         for (String bundleKey : bundle.keySet()) {
-                            data.put(key + "_" + bundleKey, bundle.getString(bundleKey));
+                            data.put(key + "_" + bundleKey, String.valueOf(bundle.get(bundleKey)));
                         }
-                    } else {
-                        String value = extras.getString(TiConvert.toString(key));
-                        if (value != null) {
-                            data.put(key, value);
-                        }
+                    } else if (value != null) {
+                        data.put(key, String.valueOf(value));
                     }
                 }
 

--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -26,7 +26,8 @@ public class PushHandlerActivity extends Activity {
 
             Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
             assert launcherIntent != null;
-            launcherIntent.addCategory(Intent.ACTION_MAIN);
+            launcherIntent.setAction(Intent.ACTION_MAIN);
+            launcherIntent.addCategory(Intent.CATEGORY_LAUNCHER);
             launcherIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             launcherIntent.putExtra("fcm_data", notification);
 

--- a/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
+++ b/android/src/firebase/cloudmessaging/TiFirebaseMessagingService.java
@@ -184,7 +184,7 @@ public class TiFirebaseMessagingService extends FirebaseMessagingService {
             }
         }
 
-        String soundValue = getString(params, "big_text");
+        String soundValue = getString(params, "sound");
         if (!soundValue.isEmpty()) {
             defaultSoundUri = Utils.getSoundUri(soundValue);
             Log.d(TAG, "showNotification custom sound: " + defaultSoundUri);


### PR DESCRIPTION
https://firebase.google.com/support/release-notes/android#messaging_v25-0-0

> Breaking Change: Updated minSdkVersion to API level 23 or higher.

Google is preparing modules to be >= API Level 23 (https://apilevels.com/). ~Current Ti SDK is still 21.~ Ti is minSDK 24 now :+1: 

* removed deprecated "sendMessage()" method
* fixed bug: `sound` parameter wasn't read
* fixed bug in intent: `Intent.ACTION_MAIN` is an action, not a category
* fix `java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String` error when value is not a string.
* fixes:
```
[WARN]  Bundle: Key fullscreen expected Bundle but value was a java.lang.Boolean.  The default value <null> was returned.
[WARN]  Bundle: Attempt to cast generated internal exception:
[WARN]  Bundle: java.lang.ClassCastException: java.lang.Boolean cannot be cast to android.os.Bundle
[WARN]  Bundle:         at android.os.Bundle.getBundle(Bundle.java:1038)
[WARN]  Bundle:         at firebase.cloudmessaging.CloudMessagingModule.getLastData(CloudMessagingModule.java:74)

[WARN]  Bundle: Key fullscreen expected String but value was a java.lang.Boolean.  The default value <null> was returned.
[WARN]  Bundle: Attempt to cast generated internal exception:
[WARN]  Bundle: java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
[WARN]  Bundle:         at android.os.BaseBundle.getString(BaseBundle.java:1456)
[WARN]  Bundle:         at firebase.cloudmessaging.CloudMessagingModule.getLastData(CloudMessagingModule.java:80)
```

[firebase.cloudmessaging-android-4.0.0.zip](https://github.com/user-attachments/files/29241717/firebase.cloudmessaging-android-4.0.0.zip)

