### PR TITLE
fix(android): resume notification taps without relaunching app

### DIFF
--- a/android/src/firebase/cloudmessaging/PushHandlerActivity.java
+++ b/android/src/firebase/cloudmessaging/PushHandlerActivity.java
@@ -6,6 +6,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
+import org.appcelerator.kroll.KrollDict;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+
 public class PushHandlerActivity extends Activity {
 
     private static final String LCAT = "FirebaseCloudMessaging";
@@ -14,7 +19,6 @@ public class PushHandlerActivity extends Activity {
     public void onCreate(Bundle savedInstanceState) {
         try {
             super.onCreate(savedInstanceState);
-            finish();
 
             CloudMessagingModule module = CloudMessagingModule.getInstance();
             Context context = getApplicationContext();
@@ -22,6 +26,13 @@ public class PushHandlerActivity extends Activity {
 
             if (module != null) {
                 module.setNotificationData(notification);
+
+                if (notification != null) {
+                    HashMap<String, Object> msg = new HashMap<>();
+                    msg.put("data", new KrollDict(new JSONObject(notification)));
+                    module.onMessageReceived(msg);
+                }
+                return;
             }
 
             Intent launcherIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());


### PR DESCRIPTION
## Summary
- Avoid relaunching the app launcher from PushHandlerActivity when the Titanium module instance is already alive.
- Deliver the tapped notification payload through didReceiveMessage instead, then finish PushHandlerActivity so Android reveals the existing task/activity.
- Keep the previous launcher fallback for cold starts where the module/runtime is not alive.

## Why
For data notifications created by TiFirebaseMessagingService, tapping the notification starts PushHandlerActivity. The previous implementation always started the app launcher afterward, even when the app was only backgrounded and the Titanium runtime was still alive. On some devices this re-enters the root activity and rebuilds the app instead of resuming the existing activity.

## Verification
- ti build -p android --build-only